### PR TITLE
Refine repository and DB helper docstrings

### DIFF
--- a/packages/infra/jukebotx_infra/db/__init__.py
+++ b/packages/infra/jukebotx_infra/db/__init__.py
@@ -1,0 +1,4 @@
+from jukebotx_infra.db.models import Base
+from jukebotx_infra.db.session import async_session_factory, engine, init_db
+
+__all__ = ["Base", "async_session_factory", "engine", "init_db"]

--- a/packages/infra/jukebotx_infra/db/models.py
+++ b/packages/infra/jukebotx_infra/db/models.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID as PyUUID, uuid4
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    """Base class for SQLAlchemy declarative models."""
+
+
+class TrackModel(Base):
+    """Database model for a Suno track."""
+
+    __tablename__ = "tracks"
+
+    id: Mapped[PyUUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    suno_url: Mapped[str] = mapped_column(String(512), unique=True, index=True, nullable=False)
+    title: Mapped[str | None] = mapped_column(String(255))
+    artist_display: Mapped[str | None] = mapped_column(String(255))
+    artist_username: Mapped[str | None] = mapped_column(String(255))
+    lyrics: Mapped[str | None] = mapped_column(Text)
+    image_url: Mapped[str | None] = mapped_column(String(1024))
+    video_url: Mapped[str | None] = mapped_column(String(1024))
+    mp3_url: Mapped[str | None] = mapped_column(String(1024))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+
+class SubmissionModel(Base):
+    """Database model for a track submission in a guild."""
+
+    __tablename__ = "submissions"
+
+    id: Mapped[PyUUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    track_id: Mapped[PyUUID] = mapped_column(UUID(as_uuid=True), ForeignKey("tracks.id"), nullable=False)
+    guild_id: Mapped[int] = mapped_column(Integer, index=True, nullable=False)
+    channel_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    message_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    author_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    submitted_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class QueueItemModel(Base):
+    """Database model for a queued track in a guild."""
+
+    __tablename__ = "queue_items"
+
+    id: Mapped[PyUUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    guild_id: Mapped[int] = mapped_column(Integer, index=True, nullable=False)
+    track_id: Mapped[PyUUID] = mapped_column(UUID(as_uuid=True), ForeignKey("tracks.id"), nullable=False)
+    requested_by: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(String(32), index=True, nullable=False)
+    position: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())

--- a/packages/infra/jukebotx_infra/db/session.py
+++ b/packages/infra/jukebotx_infra/db/session.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
+
+from jukebotx_infra.db.models import Base
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql+asyncpg://jukebotx:jukebotx@localhost:5432/jukebotx",
+)
+
+engine: AsyncEngine = create_async_engine(DATABASE_URL, pool_pre_ping=True)
+"""Async SQLAlchemy engine configured for Postgres."""
+
+async_session_factory = async_sessionmaker(engine, expire_on_commit=False)
+"""Session factory for creating async DB sessions."""
+
+
+async def init_db() -> None:
+    """Create database tables based on SQLAlchemy metadata."""
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)

--- a/packages/infra/jukebotx_infra/repos/__init__.py
+++ b/packages/infra/jukebotx_infra/repos/__init__.py
@@ -1,0 +1,5 @@
+from jukebotx_infra.repos.queue_repo import PostgresQueueRepository
+from jukebotx_infra.repos.submission_repo import PostgresSubmissionRepository
+from jukebotx_infra.repos.track_repo import PostgresTrackRepository
+
+__all__ = ["PostgresQueueRepository", "PostgresSubmissionRepository", "PostgresTrackRepository"]

--- a/packages/infra/jukebotx_infra/repos/queue_repo.py
+++ b/packages/infra/jukebotx_infra/repos/queue_repo.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy import delete, func, select, update
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from jukebotx_core.ports.repositories import QueueItem, QueueItemCreate, QueueRepository
+from jukebotx_infra.db.models import QueueItemModel
+
+
+def _now() -> datetime:
+    """Return the current UTC time."""
+    return datetime.now(timezone.utc)
+
+
+def _to_domain(item: QueueItemModel) -> QueueItem:
+    """Convert a QueueItemModel to a QueueItem domain object."""
+    return QueueItem(
+        id=item.id,
+        guild_id=item.guild_id,
+        track_id=item.track_id,
+        requested_by=item.requested_by,
+        status=item.status,
+        position=item.position,
+        created_at=item.created_at,
+        updated_at=item.updated_at,
+    )
+
+
+class PostgresQueueRepository(QueueRepository):
+    """Postgres-backed repository for queue items."""
+
+    def __init__(self, session_factory: async_sessionmaker) -> None:
+        """Initialize the repository with an async session factory."""
+        self._session_factory = session_factory
+
+    async def enqueue(self, data: QueueItemCreate) -> QueueItem:
+        """Add a new queue item for a guild."""
+        async with self._session_factory() as session:
+            max_pos = await session.scalar(
+                select(func.max(QueueItemModel.position)).where(QueueItemModel.guild_id == data.guild_id)
+            )
+            next_pos = (max_pos or 0) + 1
+            now = _now()
+            created = QueueItemModel(
+                guild_id=data.guild_id,
+                track_id=data.track_id,
+                requested_by=data.requested_by,
+                status="queued",
+                position=next_pos,
+                created_at=now,
+                updated_at=now,
+            )
+            session.add(created)
+            await session.commit()
+            await session.refresh(created)
+            return _to_domain(created)
+
+    async def get_next_unplayed(self, *, guild_id: int) -> QueueItem | None:
+        """Fetch the next queued item for a guild."""
+        async with self._session_factory() as session:
+            result = await session.scalar(
+                select(QueueItemModel)
+                .where(QueueItemModel.guild_id == guild_id, QueueItemModel.status == "queued")
+                .order_by(QueueItemModel.position.asc())
+                .limit(1)
+            )
+            return _to_domain(result) if result else None
+
+    async def mark_played(self, *, guild_id: int, queue_item_id: UUID) -> None:
+        """Mark a queue item as played."""
+        async with self._session_factory() as session:
+            result = await session.execute(
+                update(QueueItemModel)
+                .where(QueueItemModel.guild_id == guild_id, QueueItemModel.id == queue_item_id)
+                .values(status="played", updated_at=_now())
+            )
+            await session.commit()
+            if result.rowcount == 0:
+                raise KeyError(f"Queue item not found: {queue_item_id}")
+
+    async def preview(self, *, guild_id: int, limit: int) -> list[QueueItem]:
+        """Return a preview list of queued items for a guild."""
+        async with self._session_factory() as session:
+            rows = await session.scalars(
+                select(QueueItemModel)
+                .where(QueueItemModel.guild_id == guild_id, QueueItemModel.status == "queued")
+                .order_by(QueueItemModel.position.asc())
+                .limit(limit)
+            )
+            return [_to_domain(item) for item in rows]
+
+    async def clear(self, *, guild_id: int) -> None:
+        """Clear all queued items for a guild."""
+        async with self._session_factory() as session:
+            await session.execute(delete(QueueItemModel).where(QueueItemModel.guild_id == guild_id))
+            await session.commit()

--- a/packages/infra/jukebotx_infra/repos/submission_repo.py
+++ b/packages/infra/jukebotx_infra/repos/submission_repo.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from jukebotx_core.ports.repositories import Submission, SubmissionCreate, SubmissionRepository
+from jukebotx_infra.db.models import SubmissionModel
+
+
+def _now() -> datetime:
+    """Return the current UTC time."""
+    return datetime.now(timezone.utc)
+
+
+def _to_domain(submission: SubmissionModel) -> Submission:
+    """Convert a SubmissionModel to a Submission domain object."""
+    return Submission(
+        id=submission.id,
+        track_id=submission.track_id,
+        guild_id=submission.guild_id,
+        channel_id=submission.channel_id,
+        message_id=submission.message_id,
+        author_id=submission.author_id,
+        submitted_at=submission.submitted_at,
+    )
+
+
+class PostgresSubmissionRepository(SubmissionRepository):
+    """Postgres-backed repository for submissions."""
+
+    def __init__(self, session_factory: async_sessionmaker) -> None:
+        """Initialize the repository with an async session factory."""
+        self._session_factory = session_factory
+
+    async def get_first_submission_for_track_in_guild(
+        self,
+        *,
+        guild_id: int,
+        track_id: UUID,
+    ) -> Submission | None:
+        """Return the earliest submission for a track within a guild."""
+        async with self._session_factory() as session:
+            result = await session.scalar(
+                select(SubmissionModel)
+                .where(SubmissionModel.guild_id == guild_id, SubmissionModel.track_id == track_id)
+                .order_by(SubmissionModel.submitted_at.asc())
+                .limit(1)
+            )
+            return _to_domain(result) if result else None
+
+    async def create(self, data: SubmissionCreate) -> Submission:
+        """Create a new submission record."""
+        async with self._session_factory() as session:
+            created = SubmissionModel(
+                track_id=data.track_id,
+                guild_id=data.guild_id,
+                channel_id=data.channel_id,
+                message_id=data.message_id,
+                author_id=data.author_id,
+                submitted_at=_now(),
+            )
+            session.add(created)
+            await session.commit()
+            await session.refresh(created)
+            return _to_domain(created)

--- a/packages/infra/jukebotx_infra/repos/track_repo.py
+++ b/packages/infra/jukebotx_infra/repos/track_repo.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from jukebotx_core.ports.repositories import Track, TrackRepository, TrackUpsert
+from jukebotx_infra.db.models import TrackModel
+
+
+def _now() -> datetime:
+    """Return the current UTC time."""
+    return datetime.now(timezone.utc)
+
+
+def _to_domain(track: TrackModel) -> Track:
+    """Convert a TrackModel to a Track domain object."""
+    return Track(
+        id=track.id,
+        suno_url=track.suno_url,
+        title=track.title,
+        artist_display=track.artist_display,
+        artist_username=track.artist_username,
+        lyrics=track.lyrics,
+        image_url=track.image_url,
+        video_url=track.video_url,
+        mp3_url=track.mp3_url,
+        created_at=track.created_at,
+        updated_at=track.updated_at,
+    )
+
+
+class PostgresTrackRepository(TrackRepository):
+    """Postgres-backed repository for tracks."""
+
+    def __init__(self, session_factory: async_sessionmaker) -> None:
+        """Initialize the repository with an async session factory."""
+        self._session_factory = session_factory
+
+    async def get_by_suno_url(self, suno_url: str) -> Track | None:
+        """Fetch a track by its Suno URL."""
+        async with self._session_factory() as session:
+            result = await session.scalar(select(TrackModel).where(TrackModel.suno_url == suno_url))
+            return _to_domain(result) if result else None
+
+    async def upsert(self, data: TrackUpsert) -> Track:
+        """Insert or update a track record based on its Suno URL."""
+        async with self._session_factory() as session:
+            existing = await session.scalar(select(TrackModel).where(TrackModel.suno_url == data.suno_url))
+            now = _now()
+
+            if existing:
+                existing.title = data.title or existing.title
+                existing.artist_display = data.artist_display or existing.artist_display
+                existing.artist_username = data.artist_username or existing.artist_username
+                existing.lyrics = data.lyrics or existing.lyrics
+                existing.image_url = data.image_url or existing.image_url
+                existing.video_url = data.video_url or existing.video_url
+                existing.mp3_url = data.mp3_url or existing.mp3_url
+                existing.updated_at = now
+                await session.commit()
+                await session.refresh(existing)
+                return _to_domain(existing)
+
+            created = TrackModel(
+                suno_url=data.suno_url,
+                title=data.title,
+                artist_display=data.artist_display,
+                artist_username=data.artist_username,
+                lyrics=data.lyrics,
+                image_url=data.image_url,
+                video_url=data.video_url,
+                mp3_url=data.mp3_url,
+                created_at=now,
+                updated_at=now,
+            )
+            session.add(created)
+            await session.commit()
+            await session.refresh(created)
+            return _to_domain(created)
+
+    async def get_by_id(self, track_id: UUID) -> Track:
+        """Fetch a track by its UUID."""
+        async with self._session_factory() as session:
+            result = await session.get(TrackModel, track_id)
+            if result is None:
+                raise KeyError(f"Track not found: {track_id}")
+            return _to_domain(result)


### PR DESCRIPTION
### Motivation
- Improve readability and maintainability by adding concise docstrings to DB models and repositories.
- Make the semantics of session helpers and repository helper functions explicit for future maintainers.
- Address inline review comments by adding short docstrings for helper functions and adjusting spacing around class docstrings.

### Description
- Added and refined docstrings in `packages/infra/jukebotx_infra/db/models.py` for `Base`, `TrackModel`, `SubmissionModel`, and `QueueItemModel`.
- Documented session helpers and exports in `packages/infra/jukebotx_infra/db/session.py` including `engine`, `async_session_factory`, and `init_db`.
- Added concise docstrings for helper functions (`_now`, `_to_domain`) and repository classes/methods in `packages/infra/jukebotx_infra/repos/queue_repo.py`, `submission_repo.py`, and `track_repo.py`.
- Exported repository classes from `packages/infra/jukebotx_infra/repos/__init__.py` and exported DB helpers from `packages/infra/jukebotx_infra/db/__init__.py` while applying minor formatting/spacing tweaks.

### Testing
- Ran `python -m pytest` in the repository which collected 0 tests.
- `pytest` reported no tests were run and exited with code 5 (no automated tests exercised by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f92a71314832fa628e71891adf0ce)