### PR TITLE
Add `!ping` proof-of-life command for Discord bot

### DIFF
--- a/apps/bot/jukebotx_bot/main.py
+++ b/apps/bot/jukebotx_bot/main.py
@@ -48,6 +48,22 @@ def main() -> None:
 
         print(f"Connected as {client.user} (env={settings.env})")
 
+    @client.event
+    async def on_message(message: discord.Message) -> None:
+        """
+        Lightweight proof-of-life command handler.
+
+        Responds to "!ping" with "Pong!" and the current websocket latency.
+        """
+        if message.author == client.user:
+            return
+
+        if message.content.strip().lower() != "!ping":
+            return
+
+        latency_ms = int(client.latency * 1000)
+        await message.channel.send(f"Pong! ({latency_ms}ms)")
+
     client.run(settings.active_discord_token)
 
 


### PR DESCRIPTION
### Motivation
- Provide a lightweight, easy-to-run health check to confirm the Discord bot is connected and responsive.
- Surface the current websocket latency so operators can gauge connection quality.
- Ensure the check is safe and non-invasive by ignoring bot-originated messages.

### Description
- Added an `on_message` event handler in `apps/bot/jukebotx_bot/main.py` that implements a `!ping` command.
- The handler ignores messages from `client.user`, normalizes input with `strip().lower()`, and only responds to `!ping`.
- The response sends `Pong!` plus latency in milliseconds computed from `client.latency`.
- The change is limited to the `main.py` startup/client code and does not alter existing readiness checks.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69502f2326b8832f8baf636ef6fc9714)