### PR TITLE
Add MVP Discord command stubs and session management

### DIFF
--- a/apps/bot/jukebotx_bot/discord/session.py
+++ b/apps/bot/jukebotx_bot/discord/session.py
@@ -1,0 +1,100 @@
+# apps/bot/jukebotx_bot/discord/session.py
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import time
+
+
+@dataclass
+class Track:
+    url: str
+    title: str
+    requester_id: int
+    requester_name: str
+
+
+@dataclass
+class SessionState:
+    submissions_open: bool = True
+    per_user_limit: int | None = None
+    per_user_counts: dict[int, int] = field(default_factory=dict)
+    autoplay_enabled: bool = False
+    autoplay_remaining: int | None = None
+    dj_enabled: bool = False
+    dj_remaining: int | None = None
+    queue: list[Track] = field(default_factory=list)
+    now_playing: Track | None = None
+    now_playing_started_at: float | None = None
+
+    def reset(self) -> None:
+        self.submissions_open = True
+        self.per_user_limit = None
+        self.per_user_counts.clear()
+        self.autoplay_enabled = False
+        self.autoplay_remaining = None
+        self.dj_enabled = False
+        self.dj_remaining = None
+        self.queue.clear()
+        self.stop_playback()
+
+    def stop_playback(self) -> None:
+        self.now_playing = None
+        self.now_playing_started_at = None
+
+    def reset_submission_counts(self) -> None:
+        self.per_user_counts.clear()
+
+    def set_autoplay(self, remaining: int | None) -> None:
+        if remaining is None:
+            self.autoplay_enabled = True
+            self.autoplay_remaining = None
+        else:
+            self.autoplay_enabled = remaining > 0
+            self.autoplay_remaining = max(remaining, 0)
+
+    def disable_autoplay(self) -> None:
+        self.autoplay_enabled = False
+        self.autoplay_remaining = None
+
+    def set_dj(self, remaining: int | None) -> None:
+        if remaining is None:
+            self.dj_enabled = True
+            self.dj_remaining = None
+        else:
+            self.dj_enabled = remaining > 0
+            self.dj_remaining = max(remaining, 0)
+
+    def disable_dj(self) -> None:
+        self.dj_enabled = False
+        self.dj_remaining = None
+
+    def start_next_track(self) -> Track | None:
+        if not self.queue:
+            self.stop_playback()
+            return None
+
+        track = self.queue.pop(0)
+        self.now_playing = track
+        self.now_playing_started_at = time.monotonic()
+
+        if self.autoplay_enabled and self.autoplay_remaining is not None:
+            self.autoplay_remaining -= 1
+            if self.autoplay_remaining <= 0:
+                self.disable_autoplay()
+
+        if self.dj_enabled and self.dj_remaining is not None:
+            self.dj_remaining -= 1
+            if self.dj_remaining <= 0:
+                self.disable_dj()
+
+        return track
+
+
+class SessionManager:
+    def __init__(self) -> None:
+        self._sessions: dict[int, SessionState] = {}
+
+    def for_guild(self, guild_id: int) -> SessionState:
+        if guild_id not in self._sessions:
+            self._sessions[guild_id] = SessionState()
+        return self._sessions[guild_id]

--- a/apps/bot/jukebotx_bot/main.py
+++ b/apps/bot/jukebotx_bot/main.py
@@ -1,7 +1,14 @@
 # apps/bot/jukebotx_bot/main.py
 import discord
+from discord.ext import commands
 
+from jukebotx_bot.discord.session import SessionManager, Track
 from jukebotx_bot.settings import load_bot_settings
+
+
+def _is_mod(member: discord.Member) -> bool:
+    perms = member.guild_permissions
+    return bool(perms.administrator or perms.manage_guild)
 
 
 def main() -> None:
@@ -10,9 +17,10 @@ def main() -> None:
     intents = discord.Intents.default()
     intents.message_content = True
 
-    client = discord.Client(intents=intents)
+    bot = commands.Bot(command_prefix=";", intents=intents)
+    session_manager = SessionManager()
 
-    @client.event
+    @bot.event
     async def on_ready() -> None:
         """
         Discord.py lifecycle hook fired when the client has successfully connected
@@ -24,9 +32,9 @@ def main() -> None:
         """
         # Defensive: discord.py guarantees `client.user` in on_ready, but keep this explicit
         # so failures are obvious if lifecycle behavior changes.
-        assert client.user is not None, "client.user is unexpectedly None in on_ready()"
+        assert bot.user is not None, "client.user is unexpectedly None in on_ready()"
 
-        bot_name = client.user.name.lower().strip()
+        bot_name = bot.user.name.lower().strip()
         env = settings.env.lower().strip()
 
         # 1) Never allow a dev-named bot identity to run in production.
@@ -46,25 +54,354 @@ def main() -> None:
             "does NOT contain 'dev'. You are likely using the production bot token in development."
         )
 
-        print(f"Connected as {client.user} (env={settings.env})")
+        print(f"Connected as {bot.user} (env={settings.env})")
 
-    @client.event
-    async def on_message(message: discord.Message) -> None:
-        """
-        Lightweight proof-of-life command handler.
+    def get_session(ctx: commands.Context) -> SessionManager:
+        return session_manager
 
-        Responds to "!ping" with "Pong!" and the current websocket latency.
-        """
-        if message.author == client.user:
+    @bot.command(name="join")
+    async def join(ctx: commands.Context) -> None:
+        if ctx.guild is None or not isinstance(ctx.author, discord.Member):
+            await ctx.send("This command can only be used in a server.")
             return
 
-        if message.content.strip().lower() != "!ping":
+        voice_state = ctx.author.voice
+        if voice_state is None or voice_state.channel is None:
+            await ctx.send("Join a voice channel first.")
             return
 
-        latency_ms = int(client.latency * 1000)
-        await message.channel.send(f"Pong! ({latency_ms}ms)")
+        if ctx.voice_client is None:
+            await voice_state.channel.connect()
+        else:
+            await ctx.voice_client.move_to(voice_state.channel)
 
-    client.run(settings.active_discord_token)
+        await ctx.send(f"Joined {voice_state.channel.name}.")
+
+    @bot.command(name="leave")
+    async def leave(ctx: commands.Context) -> None:
+        if ctx.guild is None:
+            await ctx.send("This command can only be used in a server.")
+            return
+
+        session = get_session(ctx).for_guild(ctx.guild.id)
+        session.reset()
+
+        if ctx.voice_client is not None:
+            await ctx.voice_client.disconnect()
+
+        await ctx.send("Left the voice channel. Session reset.")
+
+    @bot.command(name="ping")
+    async def ping(ctx: commands.Context, target: str, *, message: str) -> None:
+        if ctx.guild is None or not isinstance(ctx.author, discord.Member):
+            await ctx.send("This command can only be used in a server.")
+            return
+
+        if not _is_mod(ctx.author):
+            await ctx.send("You don't have permission to use this command.")
+            return
+
+        target_norm = target.lower().strip()
+        if target_norm not in {"here", "jamsession"}:
+            await ctx.send("Target must be 'here' or 'jamsession'.")
+            return
+
+        if settings.jam_session_channel_id is None:
+            await ctx.send("Jam session channel is not configured.")
+            return
+
+        channel = ctx.guild.get_channel(settings.jam_session_channel_id)
+        if channel is None:
+            await ctx.send("Jam session channel not found.")
+            return
+
+        if target_norm == "here":
+            mention = "@here"
+        else:
+            if settings.jam_session_role_id is None:
+                await ctx.send("Jam session role is not configured.")
+                return
+            mention = f"<@&{settings.jam_session_role_id}>"
+
+        await channel.send(f"{mention} Submissions are open! {message}")
+        await ctx.send("Announcement sent.")
+
+    @bot.command(name="open")
+    async def open_submissions(ctx: commands.Context) -> None:
+        if ctx.guild is None:
+            await ctx.send("This command can only be used in a server.")
+            return
+
+        session = get_session(ctx).for_guild(ctx.guild.id)
+        session.submissions_open = True
+        session.reset_submission_counts()
+        await ctx.send("Submissions are open.")
+
+    @bot.command(name="close")
+    async def close_submissions(ctx: commands.Context) -> None:
+        if ctx.guild is None:
+            await ctx.send("This command can only be used in a server.")
+            return
+
+        session = get_session(ctx).for_guild(ctx.guild.id)
+        session.submissions_open = False
+        await ctx.send("Submissions are closed.")
+
+    @bot.command(name="add")
+    async def add(ctx: commands.Context, url: str) -> None:
+        if ctx.guild is None or not isinstance(ctx.author, discord.Member):
+            await ctx.send("This command can only be used in a server.")
+            return
+
+        if ctx.voice_client is None:
+            await ctx.send("Use ;join first.")
+            return
+
+        session = get_session(ctx).for_guild(ctx.guild.id)
+
+        if not session.submissions_open and not _is_mod(ctx.author):
+            await ctx.send("Submissions are closed.")
+            return
+
+        user_id = ctx.author.id
+        if session.per_user_limit is not None and not _is_mod(ctx.author):
+            current = session.per_user_counts.get(user_id, 0)
+            if current >= session.per_user_limit:
+                await ctx.send("You have reached the submission limit for this session.")
+                return
+
+        track = Track(
+            url=url,
+            title=url,
+            requester_id=ctx.author.id,
+            requester_name=ctx.author.display_name,
+        )
+        session.queue.append(track)
+        session.per_user_counts[user_id] = session.per_user_counts.get(user_id, 0) + 1
+
+        await ctx.send(f"Queued: {track.title} (requested by {track.requester_name}).")
+
+        if session.autoplay_enabled and session.now_playing is None:
+            started = session.start_next_track()
+            if started is not None:
+                await ctx.send(f"Now playing: {started.title} (requested by {started.requester_name}).")
+
+    @bot.command(name="q")
+    async def queue(ctx: commands.Context) -> None:
+        if ctx.guild is None:
+            await ctx.send("This command can only be used in a server.")
+            return
+
+        session = get_session(ctx).for_guild(ctx.guild.id)
+        lines: list[str] = []
+
+        if session.now_playing is not None:
+            lines.append(
+                f"Now Playing: {session.now_playing.title} (requested by {session.now_playing.requester_name})"
+            )
+        else:
+            lines.append("Now Playing: nothing")
+
+        if session.queue:
+            lines.append("Up next:")
+            for idx, track in enumerate(session.queue[:5], start=1):
+                lines.append(f"{idx}. {track.title} (requested by {track.requester_name})")
+        else:
+            lines.append("Queue is empty.")
+
+        await ctx.send("\n".join(lines))
+
+    @bot.command(name="np")
+    async def now_playing(ctx: commands.Context) -> None:
+        if ctx.guild is None:
+            await ctx.send("This command can only be used in a server.")
+            return
+
+        session = get_session(ctx).for_guild(ctx.guild.id)
+        if session.now_playing is None:
+            await ctx.send("Nothing is playing.")
+            return
+
+        await ctx.send(
+            f"Now Playing: {session.now_playing.title} (requested by {session.now_playing.requester_name})"
+        )
+
+    @bot.command(name="p")
+    async def play(ctx: commands.Context) -> None:
+        if ctx.guild is None:
+            await ctx.send("This command can only be used in a server.")
+            return
+
+        session = get_session(ctx).for_guild(ctx.guild.id)
+        if session.now_playing is not None:
+            await ctx.send(f"Already playing: {session.now_playing.title}. Use ;n to skip.")
+            return
+
+        if not session.queue:
+            await ctx.send("Queue is empty. Use ;add <url>.")
+            return
+
+        started = session.start_next_track()
+        if started is None:
+            await ctx.send("Queue is empty. Use ;add <url>.")
+            return
+
+        await ctx.send(f"Now playing: {started.title} (requested by {started.requester_name}).")
+
+    @bot.command(name="n")
+    async def skip(ctx: commands.Context) -> None:
+        if ctx.guild is None or not isinstance(ctx.author, discord.Member):
+            await ctx.send("This command can only be used in a server.")
+            return
+
+        if not _is_mod(ctx.author):
+            await ctx.send("You don't have permission to use this command.")
+            return
+
+        session = get_session(ctx).for_guild(ctx.guild.id)
+        session.stop_playback()
+        started = session.start_next_track()
+        if started is None:
+            await ctx.send("Skipped. Queue is now empty; playback stopped.")
+            return
+
+        await ctx.send(f"Skipped. Now playing: {started.title} (requested by {started.requester_name}).")
+
+    @bot.command(name="s")
+    async def stop(ctx: commands.Context) -> None:
+        if ctx.guild is None or not isinstance(ctx.author, discord.Member):
+            await ctx.send("This command can only be used in a server.")
+            return
+
+        if not _is_mod(ctx.author):
+            await ctx.send("You don't have permission to use this command.")
+            return
+
+        session = get_session(ctx).for_guild(ctx.guild.id)
+        session.stop_playback()
+        await ctx.send("Playback stopped.")
+
+    @bot.command(name="clear")
+    async def clear(ctx: commands.Context) -> None:
+        if ctx.guild is None or not isinstance(ctx.author, discord.Member):
+            await ctx.send("This command can only be used in a server.")
+            return
+
+        if not _is_mod(ctx.author):
+            await ctx.send("You don't have permission to use this command.")
+            return
+
+        session = get_session(ctx).for_guild(ctx.guild.id)
+        session.queue.clear()
+        await ctx.send("Queue cleared.")
+
+    @bot.command(name="remove")
+    async def remove(ctx: commands.Context, index: int) -> None:
+        if ctx.guild is None or not isinstance(ctx.author, discord.Member):
+            await ctx.send("This command can only be used in a server.")
+            return
+
+        if not _is_mod(ctx.author):
+            await ctx.send("You don't have permission to use this command.")
+            return
+
+        session = get_session(ctx).for_guild(ctx.guild.id)
+        if index < 1 or index > len(session.queue):
+            await ctx.send("Invalid queue index.")
+            return
+
+        track = session.queue.pop(index - 1)
+        await ctx.send(f"Removed: {track.title} (requested by {track.requester_name}).")
+
+    @bot.command(name="limit")
+    async def limit(ctx: commands.Context, limit_value: int) -> None:
+        if ctx.guild is None or not isinstance(ctx.author, discord.Member):
+            await ctx.send("This command can only be used in a server.")
+            return
+
+        if not _is_mod(ctx.author):
+            await ctx.send("You don't have permission to use this command.")
+            return
+
+        if limit_value < 1:
+            await ctx.send("Limit must be at least 1.")
+            return
+
+        session = get_session(ctx).for_guild(ctx.guild.id)
+        session.per_user_limit = limit_value
+        await ctx.send(f"Per-user submission limit set to {limit_value}.")
+
+    @bot.command(name="autoplay")
+    async def autoplay(ctx: commands.Context, value: str | None = None) -> None:
+        if ctx.guild is None or not isinstance(ctx.author, discord.Member):
+            await ctx.send("This command can only be used in a server.")
+            return
+
+        if not _is_mod(ctx.author):
+            await ctx.send("You don't have permission to use this command.")
+            return
+
+        session = get_session(ctx).for_guild(ctx.guild.id)
+
+        if value is None:
+            session.set_autoplay(None)
+            await ctx.send("Autoplay enabled until queue is empty.")
+            return
+
+        if value.lower() == "off":
+            session.disable_autoplay()
+            await ctx.send("Autoplay disabled.")
+            return
+
+        try:
+            remaining = int(value)
+        except ValueError:
+            await ctx.send("Autoplay value must be a number or 'off'.")
+            return
+
+        if remaining < 1:
+            await ctx.send("Autoplay count must be at least 1.")
+            return
+
+        session.set_autoplay(remaining)
+        await ctx.send(f"Autoplay enabled for the next {remaining} track(s).")
+
+    @bot.command(name="dj")
+    async def dj(ctx: commands.Context, value: str | None = None) -> None:
+        if ctx.guild is None or not isinstance(ctx.author, discord.Member):
+            await ctx.send("This command can only be used in a server.")
+            return
+
+        if not _is_mod(ctx.author):
+            await ctx.send("You don't have permission to use this command.")
+            return
+
+        session = get_session(ctx).for_guild(ctx.guild.id)
+
+        if value is None:
+            session.set_dj(None)
+            await ctx.send("DJ mode enabled until queue is empty.")
+            return
+
+        if value.lower() == "off":
+            session.disable_dj()
+            await ctx.send("DJ mode disabled.")
+            return
+
+        try:
+            remaining = int(value)
+        except ValueError:
+            await ctx.send("DJ value must be a number or 'off'.")
+            return
+
+        if remaining < 1:
+            await ctx.send("DJ count must be at least 1.")
+            return
+
+        session.set_dj(remaining)
+        await ctx.send(f"DJ mode enabled for the next {remaining} track(s).")
+
+    bot.run(settings.active_discord_token)
 
 
 if __name__ == "__main__":

--- a/apps/bot/jukebotx_bot/settings.py
+++ b/apps/bot/jukebotx_bot/settings.py
@@ -22,6 +22,11 @@ class BotSettings(BaseSettings):
     discord_token: str | None = Field(default=None, alias="DISCORD_TOKEN")
     dev_discord_token: str | None = Field(default=None, alias="DEV_DISCORD_TOKEN")
 
+    jam_session_channel_id: int | None = Field(
+        default=None, alias="JAM_SESSION_CHANNEL_ID"
+    )
+    jam_session_role_id: int | None = Field(default=None, alias="JAM_SESSION_ROLE_ID")
+
     # Pydantic v2 configuration
     model_config = SettingsConfigDict(
         env_file=".env",


### PR DESCRIPTION
### Motivation
- Provide MVP-ready Discord command handlers so the bot can be used on the development server with basic session flow.
- Centralize per-guild session state (queue, submissions, autoplay/DJ, now-playing) to support queue and playback commands.
- Expose jam session announcement configuration via settings so `;ping` can post to the configured channel/role.

### Description
- Replace the simple `discord.Client` handler with a `commands.Bot` and implement command stubs for `;join`, `;leave`, `;ping`, `;open`, `;close`, `;add`, `;q`, `;np`, `;p`, `;n`, `;s`, `;clear`, `;remove`, `;limit`, `;autoplay`, and `;dj` in `apps/bot/jukebotx_bot/main.py`.
- Add `apps/bot/jukebotx_bot/discord/session.py` implementing `Track`, `SessionState`, and `SessionManager` to track queues, per-user counts, autoplay/DJ counters, and now-playing state per guild.
- Extend `BotSettings` in `apps/bot/jukebotx_bot/settings.py` with `JAM_SESSION_CHANNEL_ID` and `JAM_SESSION_ROLE_ID` fields for announcement routing.
- Basic permission gating is applied via an internal `_is_mod` helper that checks `administrator` or `manage_guild` privileges for moderator-only commands.

### Testing
- No automated tests were executed for these changes.
- The changes were compiled and lint/format checks were not run as part of this rollout.
- Manual local inspection and static execution of repository listing/reading commands completed successfully.
- Further automated tests and runtime validation against a Discord dev server are recommended before production deployment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950362d5820832fb89b5d3929b86b43)