### PR TITLE
Add FFmpeg playback controller for Discord VC

### DIFF
--- a/apps/bot/Dockerfile
+++ b/apps/bot/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
+    ffmpeg \
     libffi-dev \
     libsodium-dev \
  && rm -rf /var/lib/apt/lists/*

--- a/apps/bot/jukebotx_bot/discord/audio.py
+++ b/apps/bot/jukebotx_bot/discord/audio.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import subprocess
+import threading
+from typing import Optional
+
+import discord
+
+from jukebotx_bot.discord.session import SessionState, Track
+
+
+logger = logging.getLogger(__name__)
+
+
+class GuildAudioController:
+    def __init__(self, guild_id: int, session: SessionState) -> None:
+        self.guild_id = guild_id
+        self.session = session
+        self._lock = asyncio.Lock()
+        self._current_source: Optional[discord.FFmpegPCMAudio] = None
+        self._stderr_thread: Optional[threading.Thread] = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+
+    async def play_next(self, voice_client: discord.VoiceClient) -> Track | None:
+        async with self._lock:
+            if voice_client.is_playing() or voice_client.is_paused():
+                return None
+
+            track = self.session.start_next_track()
+            if track is None:
+                return None
+
+            source = self._build_source(track.url)
+            self._current_source = source
+
+            if self._loop is None:
+                self._loop = asyncio.get_running_loop()
+
+            def _after_playback(error: Exception | None, *, current_source=source) -> None:
+                if self._loop is None:
+                    return
+                asyncio.run_coroutine_threadsafe(
+                    self._on_track_end(voice_client, current_source, error),
+                    self._loop,
+                )
+
+            voice_client.play(source, after=_after_playback)
+            return track
+
+    async def stop(self, voice_client: discord.VoiceClient) -> None:
+        async with self._lock:
+            if voice_client.is_playing() or voice_client.is_paused():
+                voice_client.stop()
+            await self._cleanup_ffmpeg()
+            self.session.stop_playback()
+
+    async def skip(self, voice_client: discord.VoiceClient) -> Track | None:
+        await self.stop(voice_client)
+        return await self.play_next(voice_client)
+
+    async def _on_track_end(
+        self,
+        voice_client: discord.VoiceClient,
+        source: discord.FFmpegPCMAudio,
+        error: Exception | None,
+    ) -> None:
+        if error is not None:
+            logger.warning("Playback error in guild %s: %s", self.guild_id, error)
+
+        async with self._lock:
+            if self._current_source is not source:
+                return
+            await self._cleanup_ffmpeg()
+            self.session.stop_playback()
+
+        if (self.session.autoplay_enabled or self.session.dj_enabled) and self.session.queue:
+            await self.play_next(voice_client)
+
+    def _build_source(self, url: str) -> discord.FFmpegPCMAudio:
+        source = discord.FFmpegPCMAudio(
+            url,
+            before_options="-reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5",
+            options="-vn",
+            stderr=subprocess.PIPE,
+        )
+        self._start_ffmpeg_logger(source)
+        return source
+
+    def _start_ffmpeg_logger(self, source: discord.FFmpegPCMAudio) -> None:
+        process = getattr(source, "process", None)
+        if process is None or process.stderr is None:
+            return
+
+        def _read_stderr() -> None:
+            for raw_line in iter(process.stderr.readline, b""):
+                if not raw_line:
+                    break
+                line = raw_line.decode(errors="replace").rstrip()
+                if line:
+                    logger.warning("FFmpeg stderr [guild=%s]: %s", self.guild_id, line)
+
+        self._stderr_thread = threading.Thread(
+            target=_read_stderr,
+            name=f"ffmpeg-stderr-{self.guild_id}",
+            daemon=True,
+        )
+        self._stderr_thread.start()
+
+    async def _cleanup_ffmpeg(self) -> None:
+        source = self._current_source
+        if source is None:
+            return
+
+        process = getattr(source, "process", None)
+        if process is not None:
+            try:
+                if process.stdin is not None:
+                    process.stdin.close()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("Failed to close ffmpeg stdin: %s", exc)
+
+            try:
+                process.terminate()
+                process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=2)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("Failed to terminate ffmpeg process: %s", exc)
+
+        try:
+            source.cleanup()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Failed to cleanup ffmpeg source: %s", exc)
+
+        self._current_source = None
+
+
+class AudioControllerManager:
+    def __init__(self) -> None:
+        self._controllers: dict[int, GuildAudioController] = {}
+
+    def for_guild(self, guild_id: int, session: SessionState) -> GuildAudioController:
+        if guild_id not in self._controllers:
+            self._controllers[guild_id] = GuildAudioController(guild_id, session)
+        return self._controllers[guild_id]

--- a/tests/test_audio_controller.py
+++ b/tests/test_audio_controller.py
@@ -1,0 +1,153 @@
+import subprocess
+from pathlib import Path
+import sys
+
+import pytest
+
+import discord
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.extend(
+    [
+        str(ROOT / "apps" / "bot"),
+        str(ROOT / "packages" / "core"),
+        str(ROOT / "packages" / "infra"),
+    ]
+)
+
+from jukebotx_bot.discord.audio import GuildAudioController
+from jukebotx_bot.discord.session import SessionState, Track
+
+
+class FakeStdin:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeProcess:
+    def __init__(self, *, raise_timeout: bool = False) -> None:
+        self.stdin = FakeStdin()
+        self.stderr = None
+        self._raise_timeout = raise_timeout
+        self.terminated = False
+        self.killed = False
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+    def kill(self) -> None:
+        self.killed = True
+
+    def wait(self, timeout: float | None = None) -> int:
+        if self._raise_timeout and not self.killed:
+            raise subprocess.TimeoutExpired(cmd="ffmpeg", timeout=timeout or 0)
+        return 0
+
+
+class FakeFFmpegPCMAudio:
+    def __init__(self, url: str, *, before_options: str, options: str, stderr) -> None:
+        self.url = url
+        self.before_options = before_options
+        self.options = options
+        self.process = FakeProcess(raise_timeout=True)
+        self.cleanup_called = False
+
+    def cleanup(self) -> None:
+        self.cleanup_called = True
+
+
+class FakeVoiceClient:
+    def __init__(self) -> None:
+        self._playing = False
+        self._paused = False
+        self.stop_called = False
+        self.play_calls: list[discord.AudioSource] = []
+
+    def is_playing(self) -> bool:
+        return self._playing
+
+    def is_paused(self) -> bool:
+        return self._paused
+
+    def play(self, source: discord.AudioSource, after) -> None:
+        self._playing = True
+        self.play_calls.append(source)
+        self.after_callback = after
+
+    def stop(self) -> None:
+        self._playing = False
+        self.stop_called = True
+
+
+@pytest.mark.asyncio
+async def test_play_next_starts_track(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(discord, "FFmpegPCMAudio", FakeFFmpegPCMAudio)
+
+    session = SessionState()
+    session.queue.append(
+        Track(url="https://example.com/track1", title="Track 1", requester_id=1, requester_name="User")
+    )
+    controller = GuildAudioController(guild_id=123, session=session)
+    voice_client = FakeVoiceClient()
+
+    started = await controller.play_next(voice_client)
+
+    assert started is not None
+    assert started.title == "Track 1"
+    assert voice_client.is_playing()
+    assert voice_client.play_calls
+
+
+@pytest.mark.asyncio
+async def test_stop_cleans_up_ffmpeg(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(discord, "FFmpegPCMAudio", FakeFFmpegPCMAudio)
+
+    session = SessionState()
+    session.queue.append(
+        Track(url="https://example.com/track1", title="Track 1", requester_id=1, requester_name="User")
+    )
+    controller = GuildAudioController(guild_id=123, session=session)
+    voice_client = FakeVoiceClient()
+
+    await controller.play_next(voice_client)
+    source = controller._current_source
+    assert source is not None
+    await controller.stop(voice_client)
+
+    assert voice_client.stop_called
+    assert controller._current_source is None
+    assert source.cleanup_called
+    assert source.process.stdin.closed
+    assert source.process.terminated
+    assert source.process.killed
+
+
+@pytest.mark.asyncio
+async def test_track_end_autoplays_next(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(discord, "FFmpegPCMAudio", FakeFFmpegPCMAudio)
+
+    session = SessionState()
+    session.autoplay_enabled = True
+    session.queue.append(
+        Track(url="https://example.com/track1", title="Track 1", requester_id=1, requester_name="User")
+    )
+    session.queue.append(
+        Track(url="https://example.com/track2", title="Track 2", requester_id=2, requester_name="User2")
+    )
+    controller = GuildAudioController(guild_id=123, session=session)
+    voice_client = FakeVoiceClient()
+
+    first = await controller.play_next(voice_client)
+    assert first is not None
+    current_source = controller._current_source
+    assert current_source is not None
+
+    voice_client._playing = False
+    await controller._on_track_end(voice_client, current_source, None)
+
+    assert session.now_playing is not None
+    assert session.now_playing.title == "Track 2"
+    assert len(voice_client.play_calls) == 2


### PR DESCRIPTION
### Motivation
- Enable playback of Suno tracks into Discord voice channels using FFmpeg and ensure a reliable per-guild audio lifecycle.
- Prevent lingering or zombie FFmpeg processes by enforcing deterministic teardown on stop/skip and track end.
- Keep one VoiceClient + one controller per guild while spawning a fresh FFmpeg process per track.

### Description
- Add `apps/bot/jukebotx_bot/discord/audio.py` which introduces `GuildAudioController` and `AudioControllerManager` to manage per-guild playback, logging, and deterministic FFmpeg cleanup (close stdin, `terminate()` with fallback `kill()`, and call `source.cleanup()`).
- Start a background thread to capture and log FFmpeg stderr for visibility into errors like broken pipes or connection resets.
- Wire the audio manager into `JukeBot` by extending `BotDeps` with `audio_manager`, and update commands to call `audio.play_next`, `audio.stop`, and `audio.skip` so playback and teardown are deterministic and autoplay handoff happens after cleanup.
- Install `ffmpeg` in `apps/bot/Dockerfile` and add `tests/test_audio_controller.py` which monkeypatches `discord.FFmpegPCMAudio` to validate play/stop/cleanup/autoplay behaviour.

### Testing
- Ran `pytest` with the new audio tests; the test suite completed successfully with `5 passed, 1 warning`.
- `tests/test_audio_controller.py` verifies that `play_next` starts playback, `stop` performs FFmpeg cleanup (stdin closed, process terminated/killed, and `cleanup()` called), and `_on_track_end` triggers autoplay into the next queued track.
- Tests use `monkeypatch` to replace `discord.FFmpegPCMAudio` with a fake that simulates process termination/timeouts to validate the cleanup logic under edge conditions.
- No runtime integration tests were run against a live Discord voice connection as part of the automated suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69506813708c832fa236dcb6531ae273)