### PR TITLE
Restrict `;playlist` to moderators

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ The bot uses **prefix commands** with `;` (configured in `apps/bot/jukebotx_bot/
 
 * `;join` — join your current voice channel
 * `;leave` — disconnect and reset the session
-* `;add <url>` — queue a track (Suno or other audio URL)
+* `;playlist <url>` — queue tracks from a Suno playlist URL
 * `;q` — show now playing + next up
 * `;np` — show now playing
 * `;p` — start playback
@@ -433,4 +433,3 @@ If you want outside contributions later:
 ## License
 
 TBD.
-


### PR DESCRIPTION
### Motivation

- Replace the single-track `;add` flow with a playlist-aware command so Suno playlists can be enqueued.
- Validate that provided URLs are Suno playlist links and ingest all discovered MP3s into the session queue.
- Automatically close submissions after a playlist is queued to prevent additional user submissions.
- Limit use of the `;playlist` command to moderators to prevent abuse of bulk-queueing.

### Description

- Added `HttpxSunoPlaylistClient` to `BotDeps` and wired it in `build_bot` as `playlist_client` for playlist scraping.
- Replaced the `@self.command(name="add")` handler with `@self.command(name="playlist")` and updated help text in `README.md` and user prompts to reference `;playlist`.
- Implemented playlist handling: validate `https://suno.com/playlist/` URLs, call `self.deps.playlist_client.fetch_playlist(url)`, iterate `playlist_data.mp3_urls` to create `Track` objects, update per-user counts, and set `session.submissions_open = False` after enqueueing.
- Enforced moderator-only access by adding an early `if not _is_mod(ctx.author)` check in the `playlist` command to return a permission error for non-mods.

### Testing

- No automated unit or integration tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950bdea33c8832f8d7d6caeb4903afb)