### PR TITLE
Use MP3 `audio_url` for playback, reject Suno page URLs, and add ffmpeg smoke test

### DIFF
--- a/apps/bot/jukebotx_bot/discord/session.py
+++ b/apps/bot/jukebotx_bot/discord/session.py
@@ -7,7 +7,8 @@ import time
 
 @dataclass
 class Track:
-    url: str
+    audio_url: str
+    page_url: str | None
     title: str
     requester_id: int
     requester_name: str

--- a/scripts/smoke_audio_urls.py
+++ b/scripts/smoke_audio_urls.py
@@ -1,0 +1,64 @@
+# scripts/smoke_audio_urls.py
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+
+from jukebotx_infra.suno.client import HttpxSunoClient
+from jukebotx_infra.suno.playlist_client import HttpxSunoPlaylistClient
+
+
+def _run_ffmpeg(url: str, label: str) -> None:
+    print(f"Running ffmpeg for {label}: {url}")
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-v",
+            "error",
+            "-i",
+            url,
+            "-t",
+            "1",
+            "-f",
+            "null",
+            "-",
+        ],
+        check=True,
+    )
+
+
+async def main() -> None:
+    song_url = os.environ.get("SUNO_SMOKE_URL")
+    playlist_url = os.environ.get("PLAYLIST_SMOKE_URL")
+
+    if not song_url or not playlist_url:
+        raise SystemExit("SUNO_SMOKE_URL and PLAYLIST_SMOKE_URL must be set")
+
+    suno_client = HttpxSunoClient()
+    playlist_client = HttpxSunoPlaylistClient()
+
+    song_data = await suno_client.fetch_track(song_url)
+    if not song_data.mp3_url:
+        raise SystemExit(f"No mp3_url found for SUNO_SMOKE_URL={song_url}")
+
+    print("Song page URL:", song_data.suno_url)
+    print("Song mp3 URL:", song_data.mp3_url)
+    _run_ffmpeg(song_data.mp3_url, "song")
+
+    playlist_data = await playlist_client.fetch_playlist(playlist_url)
+    if not playlist_data.mp3_urls:
+        raise SystemExit(f"No mp3 URLs found for PLAYLIST_SMOKE_URL={playlist_url}")
+
+    print("Playlist URL:", playlist_url)
+    print("Playlist mp3 count:", len(playlist_data.mp3_urls))
+
+    for idx, mp3_url in enumerate(playlist_data.mp3_urls[:3], start=1):
+        _run_ffmpeg(mp3_url, f"playlist[{idx}]")
+
+    if len(playlist_data.mp3_urls) > 3:
+        print("Skipping remaining playlist tracks for brevity.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
### Motivation

- FFmpeg was being passed Suno page URLs (e.g. `https://suno.com/song/...`) which produces `Invalid data found when processing input` errors. 
- Playback must consistently use the MP3/audio URL while metadata enrichment should use the page URL. 
- Prevent accidental mixing of `page_url` and `audio_url` by making the distinction explicit in the domain model. 
- Provide a quick smoke test to validate MP3 extraction and FFmpeg playback for songs and playlists.

### Description

- Change the `Track` model to include `audio_url` and `page_url` instead of a single ambiguous `url` field. 
- Update ingestion/queueing in `main.py` to set `audio_url=result.mp3_url`, set `page_url` appropriately, and skip tracks lacking an `mp3_url`. 
- Change playback to use `track.audio_url` in `GuildAudioController.play_next` and add a defensive check `_assert_audio_url` that raises `ValueError` for non-audio or Suno page URLs before creating `discord.FFmpegPCMAudio`. 
- Add `scripts/smoke_audio_urls.py` which fetches `mp3_url`s via the Suno clients and runs `ffmpeg` against the song and the first few playlist MP3 URLs to validate extraction.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695177050f8c832f869bad97305cc1ed)