### PR TITLE
Use Suno metadata for Now Playing embeds

### DIFF
--- a/apps/bot/jukebotx_bot/discord/now_playing.py
+++ b/apps/bot/jukebotx_bot/discord/now_playing.py
@@ -7,13 +7,13 @@ from jukebotx_bot.discord.session import Track
 
 def build_now_playing_embed(track: Track) -> discord.Embed:
     title = track.title or "🎵 Now Playing"
-    artist = None
-    media_url = None
+    artist = track.artist_display or "Unknown Artist"
+    media_url = track.media_url
     url = track.page_url or track.audio_url
 
     embed = discord.Embed(
         title=title or "🎵 Now Playing",
-        description=f"By **{artist}**" if artist else "Unknown Artist",
+        description=f"By **{artist}**",
         color=0x1DB954,
     )
 

--- a/apps/bot/jukebotx_bot/discord/session.py
+++ b/apps/bot/jukebotx_bot/discord/session.py
@@ -10,6 +10,8 @@ class Track:
     audio_url: str
     page_url: str | None
     title: str
+    artist_display: str | None
+    media_url: str | None
     requester_id: int
     requester_name: str
 

--- a/packages/core/jukebotx_core/use_cases/ingest_suno_links.py
+++ b/packages/core/jukebotx_core/use_cases/ingest_suno_links.py
@@ -27,6 +27,7 @@ class IngestSunoLinkInput:
 @dataclass(frozen=True)
 class IngestSunoLinkResult:
     is_duplicate_in_guild: bool
+    suno_url: str
     track_title: str | None
     artist_display: str | None
     mp3_url: str | None
@@ -111,6 +112,7 @@ class IngestSunoLink:
 
         return IngestSunoLinkResult(
             is_duplicate_in_guild=is_dup,
+            suno_url=track.suno_url,
             track_title=track.title,
             artist_display=track.artist_display,
             mp3_url=track.mp3_url,


### PR DESCRIPTION
### Motivation
- Populate the Now Playing embed with richer Suno metadata (artist name and artwork) so the bot shows meaningful track info.
- Ensure queued tracks have normalized Suno page URLs (not raw MP3 links) for the original-link field.
- Enrich playlist ingest so each queued item can display artist and media when available.

### Description
- Added `artist_display` and `media_url` fields to the `Track` dataclass in `apps/bot/jukebotx_bot/discord/session.py` to carry Suno metadata through the session.
- Updated `build_now_playing_embed` in `apps/bot/jukebotx_bot/discord/now_playing.py` to render the artist and set the embed image from `media_url` when present.
- Changed ingestion and playlist handling in `apps/bot/jukebotx_bot/main.py` to use `ingest_use_case` results (including `suno_url`, `artist_display`, and `media_url`) when constructing `Track` objects.
- Extended `IngestSunoLinkResult` in `packages/core/jukebotx_core/use_cases/ingest_suno_links.py` to include `suno_url` and return `media_url` derived from `video_url` or `image_url`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951a169c9a0832fa83c722743d9ec2f)