### PR TITLE
Ensure now playing channel is set for autoplay

### DIFF
--- a/apps/bot/jukebotx_bot/main.py
+++ b/apps/bot/jukebotx_bot/main.py
@@ -416,6 +416,7 @@ class JukeBot(commands.Bot):
                 audio = self._get_audio(ctx).for_guild(ctx.guild.id, session)
                 started = await audio.play_next(ctx.voice_client)
                 if started is not None:
+                    session.now_playing_channel_id = ctx.channel.id
                     embed = build_now_playing_embed(started)
                     await ctx.send(embed=embed)
 
@@ -473,6 +474,7 @@ class JukeBot(commands.Bot):
                 await ctx.send("Queue is empty. Use ;playlist <url>.")
                 return
 
+            session.now_playing_channel_id = ctx.channel.id
             embed = build_now_playing_embed(started)
             await ctx.send(embed=embed)
 
@@ -497,6 +499,7 @@ class JukeBot(commands.Bot):
                 await ctx.send("Skipped. Queue is now empty; playback stopped.")
                 return
 
+            session.now_playing_channel_id = ctx.channel.id
             embed = build_now_playing_embed(started)
             await ctx.send(content="Skipped.", embed=embed)
 


### PR DESCRIPTION
### Motivation
- Autoplay-triggered playback can start outside the explicit `;play` command flow and previously lacked a target channel for now-playing announcements.
- Because `discord.FFmpegPCMAudio` is a black box for playback, the bot must record the desired announcement channel when starting playback so the `after` callback can post embeds. 
- The existing `build_now_playing_embed` already includes the scraped cover art via `track.media_url`, so ensuring a channel is set allows that embed (with art) to be delivered on autoplay. 

### Description
- Set `session.now_playing_channel_id = ctx.channel.id` when autoplay starts playback from a playlist import path. 
- Ensure `session.now_playing_channel_id` is set after successfully starting playback in the `;play` command. 
- Ensure `session.now_playing_channel_id` is set when a `;skip` triggers the next track so the announcement has a target channel. 
- No changes were made to embed construction; `build_now_playing_embed` continues to include `track.media_url` as the embed image when available. 

### Testing
- No automated tests were added or executed for this change. 
- No unit or integration test runs were recorded during the rollout. 
- Static checks (linters/typechecks) were not run as part of this update. 
- Behavior relies on existing `after` callback flow to deliver the embed once `now_playing_channel_id` is set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954e3331298832f9be2f996f5d3868f)