### PR TITLE
Log autoplay/DJ transitions and now-playing announcement decisions

### DIFF
--- a/apps/bot/jukebotx_bot/discord/audio.py
+++ b/apps/bot/jukebotx_bot/discord/audio.py
@@ -82,17 +82,41 @@ class GuildAudioController:
             self.session.stop_playback()
 
         if (self.session.autoplay_enabled or self.session.dj_enabled) and self.session.queue:
+            logger.info(
+                "Autoplay/DJ active for guild %s. autoplay_enabled=%s dj_enabled=%s queue_size=%s",
+                self.guild_id,
+                self.session.autoplay_enabled,
+                self.session.dj_enabled,
+                len(self.session.queue),
+            )
             started = await self.play_next(voice_client)
             if started is not None:
                 await self._announce_now_playing(voice_client, started)
 
     async def _announce_now_playing(self, voice_client: discord.VoiceClient, track: Track) -> None:
+        logger.info(
+            "Announcing now playing for guild %s: %s (channel_id=%s)",
+            self.guild_id,
+            track.title,
+            self.session.now_playing_channel_id,
+        )
         channel_id = self.session.now_playing_channel_id
         if channel_id is None or voice_client.guild is None:
+            logger.info(
+                "Skipping now playing announcement for guild %s: channel_id=%s guild=%s",
+                self.guild_id,
+                channel_id,
+                voice_client.guild is not None,
+            )
             return
 
         channel = voice_client.guild.get_channel(channel_id)
         if channel is None or not isinstance(channel, (discord.TextChannel, discord.Thread)):
+            logger.info(
+                "Skipping now playing announcement for guild %s: channel not found or invalid (%s)",
+                self.guild_id,
+                channel,
+            )
             return
 
         embed = build_now_playing_embed(track)


### PR DESCRIPTION
### Motivation
- Provide visibility into the playback decision path when `autoplay` or `dj` mode are active so Now Playing behavior can be diagnosed. 
- Make it easier to see when the bot advances playback and whether a Now Playing announcement is attempted or skipped.

### Description
- Added an `info` log in `GuildAudioController._on_track_end` when `self.session.autoplay_enabled` or `self.session.dj_enabled` are active and `self.session.queue` is non-empty. 
- Added an `info` log at the start of `GuildAudioController._announce_now_playing` that records the `track.title` and `self.session.now_playing_channel_id`.
- Added `info` logs to record skip reasons when `channel_id` is `None` or `voice_client.guild` is missing, and when the channel is not found or not a `TextChannel`/`Thread`.
- Changes are contained in `apps/bot/jukebotx_bot/discord/audio.py` and are logging-only (no playback logic changes).

### Testing
- No automated tests were run for this change because it is a log-only modification.
- The change was committed locally and is intended to aid manual/runtime diagnosis of Now Playing behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954e6e024ec832fb272d548e1a5b905)