### PR TITLE
Use DB queue ordering for bot playback

### DIFF
--- a/packages/core/jukebotx_core/ports/repositories.py
+++ b/packages/core/jukebotx_core/ports/repositories.py
@@ -85,6 +85,9 @@ class TrackRepository:
     async def get_by_suno_url(self, suno_url: str) -> Track | None:
         raise NotImplementedError
 
+    async def get_by_id(self, track_id: UUID) -> Track:
+        raise NotImplementedError
+
     async def upsert(self, data: TrackUpsert) -> Track:
         raise NotImplementedError
 

--- a/packages/core/jukebotx_core/use_cases/get_next_track.py
+++ b/packages/core/jukebotx_core/use_cases/get_next_track.py
@@ -2,14 +2,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from uuid import UUID
 
 from jukebotx_core.ports.repositories import QueueItem, QueueRepository, Track, TrackRepository
 
 
 @dataclass(frozen=True)
 class NextTrackResult:
-    queue_item_id: UUID
+    queue_item: QueueItem
     track: Track
 
 
@@ -27,8 +26,5 @@ class GetNextTrack:
         if qi is None:
             return None
 
-        # We need a way to load by track_id; simplest is add a method, but
-        # we can also add it later. For now, assume track_repo can resolve URL-only.
-        # If you haven't implemented get_by_id yet, add it to the port and repos.
-        track = await self._track_repo.get_by_id(qi.track_id)  # type: ignore[attr-defined]
-        return NextTrackResult(queue_item_id=qi.id, track=track)
+        track = await self._track_repo.get_by_id(qi.track_id)
+        return NextTrackResult(queue_item=qi, track=track)

--- a/packages/core/jukebotx_core/use_cases/ingest_suno_links.py
+++ b/packages/core/jukebotx_core/use_cases/ingest_suno_links.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from uuid import UUID
 
 from jukebotx_core.ports.repositories import (
     QueueItemCreate,
@@ -27,6 +28,7 @@ class IngestSunoLinkInput:
 @dataclass(frozen=True)
 class IngestSunoLinkResult:
     is_duplicate_in_guild: bool
+    track_id: UUID
     suno_url: str
     track_title: str | None
     artist_display: str | None
@@ -112,6 +114,7 @@ class IngestSunoLink:
 
         return IngestSunoLinkResult(
             is_duplicate_in_guild=is_dup,
+            track_id=track.id,
             suno_url=track.suno_url,
             track_title=track.title,
             artist_display=track.artist_display,


### PR DESCRIPTION
### Motivation
- Make the database the source of truth for queue ordering and playback state instead of the in-memory `SessionState.queue` list.
- Ensure multi-guild correctness and durable ordering by enqueuing via the `QueueRepository` and reading next items from the DB.
- Avoid mismatches between in-memory queue and persisted queue when ingesting tracks or playlists.
- Allow playback logic to mark queue items as played in the DB so history and replayability are correct.

### Description
- Replaced direct `session.queue.append(...)` in `on_message` and `playlist` handling with `QueueRepository.enqueue` using `QueueItemCreate` and stopped adding tracks to the in-memory list.
- Switched playback to use the `GetNextTrack` use case and to `MarkTrackPlayed` when items are skipped/finished, wiring these into `AudioControllerManager` and `GuildAudioController`.
- Added `now_playing_queue_item_id` and `start_playback` to `SessionState` to record the DB `QueueItem` currently playing and to consume autoplay/DJ counters from the new API.
- Updated `;q`, `;play`, `;remove`, and `;clear` commands to use `GetQueuePreview`, `GetQueuePreview` + `TrackRepository.get_by_id`, `MarkTrackPlayed`, and `ClearQueue` respectively, and added fallback `Track` upsert logic when playlist items lack an existing track id.
- Extended repository port with `TrackRepository.get_by_id`, updated `GetNextTrack` to return the `QueueItem` and `Track`, and returned `track_id` from `IngestSunoLinkResult` to enable enqueuing.
- Wired DB-backed `PostgresQueueRepository`, `PostgresTrackRepository`, and related use cases into `build_bot()` and passed use cases into the audio manager.

### Testing
- No automated tests were executed as part of this change.
- Manual build / static checks were not requested and therefore not run.
- Runtime behavior should be validated in an integration environment (enqueue/play/skip/remove flows).
- Unit tests covering `GetNextTrack`, `MarkTrackPlayed`, and `GetQueuePreview` are recommended to be run after wiring.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955a9475e1c832f986924b9deb27b43)