### PR TITLE
Use Postgres repositories in smoke ingest script

### DIFF
--- a/scripts/smoke_ingest.py
+++ b/scripts/smoke_ingest.py
@@ -3,19 +3,19 @@ from __future__ import annotations
 import asyncio
 
 from jukebotx_core.use_cases.ingest_suno_links import IngestSunoLink, IngestSunoLinkInput
-from jukebotx_infra.repos.memory import (
-    InMemoryQueueRepository,
-    InMemorySubmissionRepository,
-    InMemoryTrackRepository,
-)
+from jukebotx_infra.db import async_session_factory, init_db
+from jukebotx_infra.repos.queue_repo import PostgresQueueRepository
+from jukebotx_infra.repos.submission_repo import PostgresSubmissionRepository
+from jukebotx_infra.repos.track_repo import PostgresTrackRepository
 from jukebotx_infra.suno.client import HttpxSunoClient
 
 
 async def main() -> None:
     suno = HttpxSunoClient()
-    tracks = InMemoryTrackRepository()
-    submissions = InMemorySubmissionRepository()
-    queue = InMemoryQueueRepository()
+    await init_db()
+    tracks = PostgresTrackRepository(async_session_factory)
+    submissions = PostgresSubmissionRepository(async_session_factory)
+    queue = PostgresQueueRepository(async_session_factory)
 
     ingest = IngestSunoLink(
         suno_client=suno,


### PR DESCRIPTION
### Motivation

- Replace ephemeral in-memory storage in `scripts/smoke_ingest.py` with Postgres-backed repositories so the smoke script exercises real DB reads and writes.
- Reuse the same `async_session_factory` used by the bot to ensure consistent DB connection configuration.
- Ensure database tables exist before running ingest by invoking `init_db()` so the script can operate against an empty or new database.

### Description

- Replaced imports of `InMemoryTrackRepository`, `InMemorySubmissionRepository`, and `InMemoryQueueRepository` with `PostgresTrackRepository`, `PostgresSubmissionRepository`, and `PostgresQueueRepository`.
- Imported `async_session_factory` and `init_db` from `jukebotx_infra.db` and updated the module imports accordingly.
- Added `await init_db()` at startup and instantiated the Postgres repositories with `async_session_factory`.
- Did not change the ingest business logic; only the repository wiring and DB initialization were updated.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69563f655074832faeb94cf93db5639c)