### PR TITLE
Add `;setlist` export and clear session submissions on `;leave`

### DIFF
--- a/packages/core/jukebotx_core/ports/repositories.py
+++ b/packages/core/jukebotx_core/ports/repositories.py
@@ -39,6 +39,17 @@ class Submission:
 
 
 @dataclass(frozen=True)
+class SubmissionTrackInfo:
+    """
+    Track details joined to a submission for setlist exports.
+    """
+    artist_display: str | None
+    title: str | None
+    suno_url: str
+    mp3_url: str | None
+
+
+@dataclass(frozen=True)
 class QueueItem:
     """
     Guild-scoped queue item; "played" is per guild, not global.


### PR DESCRIPTION
### Motivation

- Provide hosts an easy way to export the current session as a text setlist via `;setlist` using stored DB submissions.  
- Ensure session data is cleaned up when a host ends a session with `;leave` so the database doesn't retain stale submissions or queued items.  

### Description

- Add `SubmissionTrackInfo` to the repository port and implement `list_tracks_for_channel` and `clear_for_channel` on `PostgresSubmissionRepository` to fetch and remove submission+track data for a guild/channel.  
- Wire `submission_repo` and `queue_repo` into `BotDeps` and `build_bot` so commands can use the Postgres-backed repos.  
- Update the `;leave` command to call `queue_repo.clear` and `submission_repo.clear_for_channel` to remove queued items and submissions for the session.  
- Add the `;setlist` command which queries submissions for the channel, builds a filename based on the voice channel name and date, writes a `.txt` file of `artist - title - url` lines to a temp file, DMs it to the host as an attachment, and cleans up the temp file.  

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69564926e710832f8968b5f1157a6685)