### PR TITLE
Prefer static image URLs for Suno embeds

### DIFF
--- a/packages/core/jukebotx_core/use_cases/ingest_suno_links.py
+++ b/packages/core/jukebotx_core/use_cases/ingest_suno_links.py
@@ -116,6 +116,6 @@ class IngestSunoLink:
             track_title=track.title,
             artist_display=track.artist_display,
             mp3_url=track.mp3_url,
-            media_url=track.video_url or track.image_url,
+            media_url=track.image_url or track.video_url,
             queued=queued,
         )

--- a/packages/infra/jukebotx_infra/suno/client.py
+++ b/packages/infra/jukebotx_infra/suno/client.py
@@ -29,7 +29,7 @@ class SunoTrackData:
 
     @property
     def media_url(self) -> str | None:
-        return self.video_url or self.image_url
+        return self.image_url or self.video_url
 
 
 class SunoScrapeError(RuntimeError):


### PR DESCRIPTION
### Motivation
- Some Suno tracks include MP4 videos which were being selected as the preferred media, causing video files to be embedded instead of static images.
- Static images are preferable for embeds to avoid large video attachments and to provide consistent thumbnails.
- The ingest result should be aligned with the same image-first media preference used by the client.

### Description
- Change `SunoTrackData.media_url` in `packages/infra/jukebotx_infra/suno/client.py` to return `image_url` before `video_url`.
- Update the ingest use case in `packages/core/jukebotx_core/use_cases/ingest_suno_links.py` to set `media_url` from `image_url` before falling back to `video_url`.
- Adjusted code to prefer static images for Suno embeds so both client and ingest layers are consistent.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956a2cd6c90832f981056fd0e8d5eb0)