### PR TITLE
Add GIF generation queue, store gif_url, enqueue on ingest, and cleanup on leave

### DIFF
--- a/apps/bot/jukebotx_bot/discord/session.py
+++ b/apps/bot/jukebotx_bot/discord/session.py
@@ -3,15 +3,18 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import time
+from uuid import UUID
 
 
 @dataclass
 class Track:
+    track_id: UUID | None
     audio_url: str
     page_url: str | None
     title: str
     artist_display: str | None
     media_url: str | None
+    gif_url: str | None
     requester_id: int
     requester_name: str
 
@@ -44,6 +47,15 @@ class SessionState:
         self.queue.clear()
         self.now_playing_channel_id = None
         self.stop_playback()
+
+    def collect_gif_cleanup(self) -> list[tuple[UUID, str]]:
+        items: list[tuple[UUID, str]] = []
+        for track in self.queue:
+            if track.gif_url and track.track_id:
+                items.append((track.track_id, track.gif_url))
+        if self.now_playing and self.now_playing.gif_url and self.now_playing.track_id:
+            items.append((self.now_playing.track_id, self.now_playing.gif_url))
+        return items
 
     def stop_playback(self) -> None:
         self.now_playing = None

--- a/packages/core/jukebotx_core/ports/gif_generation_queue.py
+++ b/packages/core/jukebotx_core/ports/gif_generation_queue.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+
+@dataclass(frozen=True)
+class GifGenerationRequest:
+    track_id: UUID
+    video_url: str
+
+
+@dataclass(frozen=True)
+class GifCleanupItem:
+    track_id: UUID
+    gif_url: str
+
+
+class GifGenerationQueue:
+    async def enqueue(self, request: GifGenerationRequest) -> None:
+        raise NotImplementedError
+
+    async def delete_generated_gifs(self, items: list[GifCleanupItem]) -> None:
+        raise NotImplementedError

--- a/packages/core/jukebotx_core/ports/repositories.py
+++ b/packages/core/jukebotx_core/ports/repositories.py
@@ -17,6 +17,7 @@ class Track:
     artist_display: str | None
     artist_username: str | None
     lyrics: str | None
+    gif_url: str | None
     image_url: str | None
     video_url: str | None
     mp3_url: str | None
@@ -71,6 +72,7 @@ class TrackUpsert:
     artist_display: str | None
     artist_username: str | None
     lyrics: str | None
+    gif_url: str | None
     image_url: str | None
     video_url: str | None
     mp3_url: str | None
@@ -96,7 +98,13 @@ class TrackRepository:
     async def get_by_suno_url(self, suno_url: str) -> Track | None:
         raise NotImplementedError
 
+    async def get_by_id(self, track_id: UUID) -> Track:
+        raise NotImplementedError
+
     async def upsert(self, data: TrackUpsert) -> Track:
+        raise NotImplementedError
+
+    async def update_gif_url(self, *, track_id: UUID, gif_url: str | None) -> Track:
         raise NotImplementedError
 
 

--- a/packages/core/jukebotx_core/ports/suno_client.py
+++ b/packages/core/jukebotx_core/ports/suno_client.py
@@ -20,7 +20,7 @@ class SunoTrackData:
 
     @property
     def media_url(self) -> str | None:
-        return self.video_url or self.image_url
+        return self.image_url or self.video_url
 
 
 class SunoClient:

--- a/packages/infra/jukebotx_infra/db/models.py
+++ b/packages/infra/jukebotx_infra/db/models.py
@@ -23,6 +23,7 @@ class TrackModel(Base):
     artist_display: Mapped[str | None] = mapped_column(String(255))
     artist_username: Mapped[str | None] = mapped_column(String(255))
     lyrics: Mapped[str | None] = mapped_column(Text)
+    gif_url: Mapped[str | None] = mapped_column(String(1024))
     image_url: Mapped[str | None] = mapped_column(String(1024))
     video_url: Mapped[str | None] = mapped_column(String(1024))
     mp3_url: Mapped[str | None] = mapped_column(String(1024))
@@ -60,4 +61,3 @@ class QueueItemModel(Base):
     position: Mapped[int] = mapped_column(Integer, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
-

--- a/packages/infra/jukebotx_infra/gif_generation_queue.py
+++ b/packages/infra/jukebotx_infra/gif_generation_queue.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+from urllib.parse import urlparse
+from uuid import UUID
+
+from jukebotx_core.ports.gif_generation_queue import (
+    GifCleanupItem,
+    GifGenerationQueue,
+    GifGenerationRequest,
+)
+from jukebotx_core.ports.repositories import TrackRepository
+
+
+_LOG = logging.getLogger(__name__)
+
+
+class GifGenerator(Protocol):
+    async def generate(self, *, track_id: UUID, video_url: str) -> str | None:
+        raise NotImplementedError
+
+
+@dataclass
+class NoopGifGenerator:
+    async def generate(self, *, track_id: UUID, video_url: str) -> str | None:
+        _LOG.info("Skipping GIF generation for track %s (no generator configured).", track_id)
+        return None
+
+
+class InProcessGifGenerationQueue(GifGenerationQueue):
+    def __init__(
+        self,
+        *,
+        track_repo: TrackRepository,
+        generator: GifGenerator | None = None,
+    ) -> None:
+        self._track_repo = track_repo
+        self._generator = generator or NoopGifGenerator()
+        self._queue: asyncio.Queue[GifGenerationRequest] = asyncio.Queue()
+        self._worker_task: asyncio.Task[None] | None = None
+
+    async def enqueue(self, request: GifGenerationRequest) -> None:
+        self._ensure_worker()
+        await self._queue.put(request)
+
+    async def delete_generated_gifs(self, items: list[GifCleanupItem]) -> None:
+        for item in items:
+            await self._delete_gif(item)
+
+    def _ensure_worker(self) -> None:
+        if self._worker_task is None or self._worker_task.done():
+            loop = asyncio.get_running_loop()
+            self._worker_task = loop.create_task(self._run_worker())
+
+    async def _run_worker(self) -> None:
+        while True:
+            request = await self._queue.get()
+            try:
+                gif_url = await self._generator.generate(
+                    track_id=request.track_id,
+                    video_url=request.video_url,
+                )
+                if gif_url:
+                    await self._track_repo.update_gif_url(track_id=request.track_id, gif_url=gif_url)
+            except Exception as exc:
+                _LOG.warning("Failed to generate GIF for track %s: %s", request.track_id, exc)
+            finally:
+                self._queue.task_done()
+
+    async def _delete_gif(self, item: GifCleanupItem) -> None:
+        path = self._url_to_path(item.gif_url)
+        if path is None:
+            return
+        try:
+            Path(path).unlink(missing_ok=True)
+        except OSError as exc:
+            _LOG.warning("Failed to delete GIF %s: %s", item.gif_url, exc)
+            return
+        await self._track_repo.update_gif_url(track_id=item.track_id, gif_url=None)
+
+    def _url_to_path(self, gif_url: str) -> str | None:
+        parsed = urlparse(gif_url)
+        if parsed.scheme in ("", "file"):
+            return os.path.abspath(parsed.path)
+        return None

--- a/packages/infra/jukebotx_infra/repos/memory.py
+++ b/packages/infra/jukebotx_infra/repos/memory.py
@@ -48,6 +48,7 @@ class InMemoryTrackRepository(TrackRepository):
                 artist_display=data.artist_display or existing.artist_display,
                 artist_username=data.artist_username or existing.artist_username,
                 lyrics=data.lyrics or existing.lyrics,
+                gif_url=data.gif_url if data.gif_url is not None else existing.gif_url,
                 image_url=data.image_url or existing.image_url,
                 video_url=data.video_url or existing.video_url,
                 mp3_url=data.mp3_url or existing.mp3_url,
@@ -64,6 +65,7 @@ class InMemoryTrackRepository(TrackRepository):
             artist_display=data.artist_display,
             artist_username=data.artist_username,
             lyrics=data.lyrics,
+            gif_url=data.gif_url,
             image_url=data.image_url,
             video_url=data.video_url,
             mp3_url=data.mp3_url,
@@ -73,6 +75,14 @@ class InMemoryTrackRepository(TrackRepository):
         self._by_id[track_id] = track
         self._by_url[data.suno_url] = track_id
         return track
+
+    async def update_gif_url(self, *, track_id: UUID, gif_url: str | None) -> Track:
+        existing = self._by_id.get(track_id)
+        if existing is None:
+            raise KeyError(f"Track not found: {track_id}")
+        updated = replace(existing, gif_url=gif_url, updated_at=_now())
+        self._by_id[track_id] = updated
+        return updated
 
 
 class InMemorySubmissionRepository(SubmissionRepository):

--- a/packages/infra/jukebotx_infra/repos/track_repo.py
+++ b/packages/infra/jukebotx_infra/repos/track_repo.py
@@ -24,6 +24,7 @@ def _to_domain(track: TrackModel) -> Track:
         artist_display=track.artist_display,
         artist_username=track.artist_username,
         lyrics=track.lyrics,
+        gif_url=track.gif_url,
         image_url=track.image_url,
         video_url=track.video_url,
         mp3_url=track.mp3_url,
@@ -56,6 +57,8 @@ class PostgresTrackRepository(TrackRepository):
                 existing.artist_display = data.artist_display or existing.artist_display
                 existing.artist_username = data.artist_username or existing.artist_username
                 existing.lyrics = data.lyrics or existing.lyrics
+                if data.gif_url is not None:
+                    existing.gif_url = data.gif_url
                 existing.image_url = data.image_url or existing.image_url
                 existing.video_url = data.video_url or existing.video_url
                 existing.mp3_url = data.mp3_url or existing.mp3_url
@@ -70,6 +73,7 @@ class PostgresTrackRepository(TrackRepository):
                 artist_display=data.artist_display,
                 artist_username=data.artist_username,
                 lyrics=data.lyrics,
+                gif_url=data.gif_url,
                 image_url=data.image_url,
                 video_url=data.video_url,
                 mp3_url=data.mp3_url,
@@ -87,4 +91,15 @@ class PostgresTrackRepository(TrackRepository):
             result = await session.get(TrackModel, track_id)
             if result is None:
                 raise KeyError(f"Track not found: {track_id}")
+            return _to_domain(result)
+
+    async def update_gif_url(self, *, track_id: UUID, gif_url: str | None) -> Track:
+        """Update the gif_url for a track."""
+        async with self._session_factory() as session:
+            result = await session.get(TrackModel, track_id)
+            if result is None:
+                raise KeyError(f"Track not found: {track_id}")
+            result.gif_url = gif_url
+            await session.commit()
+            await session.refresh(result)
             return _to_domain(result)

--- a/scripts/smoke_ingest.py
+++ b/scripts/smoke_ingest.py
@@ -4,6 +4,7 @@ import asyncio
 
 from jukebotx_core.use_cases.ingest_suno_links import IngestSunoLink, IngestSunoLinkInput
 from jukebotx_infra.db import async_session_factory, init_db
+from jukebotx_infra.gif_generation_queue import InProcessGifGenerationQueue
 from jukebotx_infra.repos.queue_repo import PostgresQueueRepository
 from jukebotx_infra.repos.submission_repo import PostgresSubmissionRepository
 from jukebotx_infra.repos.track_repo import PostgresTrackRepository
@@ -16,12 +17,14 @@ async def main() -> None:
     tracks = PostgresTrackRepository(async_session_factory)
     submissions = PostgresSubmissionRepository(async_session_factory)
     queue = PostgresQueueRepository(async_session_factory)
+    gif_queue = InProcessGifGenerationQueue(track_repo=tracks)
 
     ingest = IngestSunoLink(
         suno_client=suno,
         track_repo=tracks,
         submission_repo=submissions,
         queue_repo=queue,
+        gif_queue=gif_queue,
     )
 
     url = "https://suno.com/..."  # replace


### PR DESCRIPTION
### Motivation
- Support generating GIF thumbnails for tracks that only provide a `video_url` and prefer GIFs for displayed media.
- Offload GIF generation to a background queue abstraction to avoid blocking ingest and to allow pluggable infra implementations.
- Persist generated GIF locations on the `Track` model so media selection can prefer GIFs.
- Ensure generated GIFs are removed when a session ends to avoid orphaned files.

### Description
- Introduce a GIF queue port at `packages/core/jukebotx_core/ports/gif_generation_queue.py` with `GifGenerationQueue`, `GifGenerationRequest`, and `GifCleanupItem`, and add an in-process infra worker `InProcessGifGenerationQueue` in `packages/infra/jukebotx_infra/gif_generation_queue.py`.
- Add `gif_url` to the domain `Track` and `TrackUpsert`, add `gif_url` column to `TrackModel`, and implement `update_gif_url` and `gif_url` handling in `PostgresTrackRepository` and in-memory repo.
- Wire ingest to enqueue a GIF job via `IngestSunoLink` when a track has a `video_url` but no `image_url`, and change media selection to prefer `gif_url` then `image_url` then `video_url` (also adjust `SunoTrackData.media_url` ordering).
- Extend session `Track` with `track_id` and `gif_url`, add `collect_gif_cleanup()` in `SessionState`, and update the `leave` command to call `GifGenerationQueue.delete_generated_gifs` with `GifCleanupItem` instances; also wire `gif_queue` into `build_bot` and update smoke/tests to inject a fake or in-process queue.

### Testing
- No automated tests were executed as part of this change (no `pytest` run in the rollout).
- The unit test `tests/test_suno_ingest.py` was updated to inject a `FakeGifQueue` to cover wiring, but execution was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956aaed8d1c832f80254e4a05f5682f)