### PR TITLE
Add API endpoints for queue previews, session tracks, and track audio

### DIFF
--- a/apps/api/jukebotx_api/schemas.py
+++ b/apps/api/jukebotx_api/schemas.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class TrackSummary(BaseModel):
+    id: UUID
+    suno_url: str
+    title: str | None
+    artist_display: str | None
+    artist_username: str | None
+    image_url: str | None
+    video_url: str | None
+    mp3_url: str | None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class QueueItemSummary(BaseModel):
+    id: UUID
+    position: int
+    status: str
+    requested_by: int
+    created_at: datetime
+    updated_at: datetime
+    track: TrackSummary
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class QueuePreviewResponse(BaseModel):
+    items: list[QueueItemSummary]
+
+
+class NextQueueItemResponse(BaseModel):
+    queue_item: QueueItemSummary | None
+
+
+class SessionTrackResponse(BaseModel):
+    track_id: UUID
+    artist_display: str | None
+    title: str | None
+    suno_url: str
+    mp3_url: str | None
+

--- a/packages/core/jukebotx_core/ports/repositories.py
+++ b/packages/core/jukebotx_core/ports/repositories.py
@@ -43,6 +43,7 @@ class SubmissionTrackInfo:
     """
     Track details joined to a submission for setlist exports.
     """
+    track_id: UUID
     artist_display: str | None
     title: str | None
     suno_url: str

--- a/packages/infra/jukebotx_infra/repos/submission_repo.py
+++ b/packages/infra/jukebotx_infra/repos/submission_repo.py
@@ -92,6 +92,7 @@ class PostgresSubmissionRepository(SubmissionRepository):
             )
             return [
                 SubmissionTrackInfo(
+                    track_id=track.id,
                     artist_display=track.artist_display,
                     title=track.title,
                     suno_url=track.suno_url,


### PR DESCRIPTION
### Motivation
- Provide HTTP endpoints so the web UI and external clients can read guild queues, peek the next item, list session tracks, and fetch track details/audio.
- Enforce OAuth session-based auth and guild-scoped access checks so API access mirrors bot permissions via `require_session` and per-guild validation.
- Include track identifiers in submission listings so the frontend can resolve and play audio for session tracks.

### Description
- Added `apps/api/jukebotx_api/schemas.py` with Pydantic response schemas like `TrackSummary`, `QueueItemSummary`, and `QueuePreviewResponse`.
- Implemented new endpoints in `apps/api/jukebotx_api/main.py` for `GET /guilds/{guild_id}/queue`, `GET /guilds/{guild_id}/queue/next`, `GET /guilds/{guild_id}/channels/{channel_id}/session/tracks`, `GET /tracks/{track_id}`, and `GET /tracks/{track_id}/audio`, wired to Postgres repos via `get_queue_repo`, `get_track_repo`, and `get_submission_repo` helpers.
- Added `ensure_guild_access` and `require_track` helpers to centralize guild authorization and 404 handling for missing tracks.
- Updated the domain port and infra repo to include track IDs by adding `track_id` to `SubmissionTrackInfo` in `packages/core/jukebotx_core/ports/repositories.py` and returning it from `packages/infra/jukebotx_infra/repos/submission_repo.py`.

### Testing
- No automated tests were executed for this change.
- Basic type/usage is exercised by importing and wiring existing `PostgresTrackRepository`, `PostgresQueueRepository`, and `PostgresSubmissionRepository` in the new endpoints.
- Manual runtime validation is expected when the API is started against the configured database and OAuth settings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956d86a1b34832f9091b52454877342)