### PR TITLE
Add FastAPI landing page with Jinja2 templates and static assets

### DIFF
--- a/apps/api/jukebotx_api/static/styles.css
+++ b/apps/api/jukebotx_api/static/styles.css
@@ -1,0 +1,123 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background-color: #f6f7fb;
+  color: #1c1e26;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 48px 24px 72px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.subtitle {
+  margin: 0;
+  color: #4c4f5c;
+}
+
+.card {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 10px 30px rgba(20, 24, 40, 0.08);
+}
+
+.link-list {
+  list-style: none;
+  padding: 0;
+  margin: 16px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.link-list li {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.link-list a {
+  text-decoration: none;
+  color: #3944f7;
+  font-weight: 600;
+}
+
+.guild {
+  font-weight: 600;
+  color: #1c1e26;
+}
+
+.form-row {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  align-items: end;
+  margin-top: 16px;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-weight: 600;
+}
+
+input {
+  padding: 10px 12px;
+  border: 1px solid #d7d9e0;
+  border-radius: 8px;
+  font-size: 14px;
+}
+
+button,
+.primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  border-radius: 8px;
+  border: none;
+  background: #3944f7;
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.secondary {
+  background: #e2e5f1;
+  color: #2e3142;
+}
+
+.hint {
+  margin-top: 12px;
+  color: #5b6072;
+  font-size: 14px;
+}
+
+code {
+  background: #f1f2f8;
+  padding: 2px 6px;
+  border-radius: 6px;
+}

--- a/apps/api/jukebotx_api/templates/index.html
+++ b/apps/api/jukebotx_api/templates/index.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>JukeBotx</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header class="header">
+        <h1>JukeBotx API</h1>
+        <p class="subtitle">Quick links for the API endpoints and Discord login.</p>
+      </header>
+
+      {% if session %}
+        <section class="card">
+          <h2>Welcome back, {{ session.display_name }}!</h2>
+          <p>Your session is active. Use the links below to browse queues.</p>
+          {% if guild_ids %}
+            <ul class="link-list">
+              {% for guild_id in guild_ids %}
+                <li>
+                  <span class="guild">Guild {{ guild_id }}</span>
+                  <a href="/guilds/{{ guild_id }}/queue">Queue preview</a>
+                  <a href="/guilds/{{ guild_id }}/queue/next">Next queue item</a>
+                </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p>No guilds are available on your session.</p>
+          {% endif %}
+        </section>
+
+        <section class="card">
+          <h2>Session tracks lookup</h2>
+          <p>Enter a guild and channel ID to inspect session tracks.</p>
+          <form id="session-form" class="form-row">
+            <label>
+              Guild ID
+              <input type="text" name="guild_id" placeholder="1234567890" required />
+            </label>
+            <label>
+              Channel ID
+              <input type="text" name="channel_id" placeholder="0987654321" required />
+            </label>
+            <button type="submit">Open session tracks</button>
+          </form>
+          <p class="hint">Endpoint: <code>/guilds/&lt;guild_id&gt;/channels/&lt;channel_id&gt;/session/tracks</code></p>
+        </section>
+
+        <section class="card">
+          <form method="post" action="/auth/logout">
+            <button type="submit" class="secondary">Log out</button>
+          </form>
+        </section>
+      {% else %}
+        <section class="card">
+          <h2>Get started</h2>
+          <p>Log in with Discord to access your guild queues.</p>
+          <a class="primary" href="/auth/discord/login">Login with Discord</a>
+        </section>
+      {% endif %}
+    </main>
+    <script>
+      const form = document.getElementById("session-form");
+      if (form) {
+        form.addEventListener("submit", (event) => {
+          event.preventDefault();
+          const guildId = form.guild_id.value.trim();
+          const channelId = form.channel_id.value.trim();
+          if (!guildId || !channelId) {
+            return;
+          }
+          window.location.href = `/guilds/${guildId}/channels/${channelId}/session/tracks`;
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ alembic = "^1.17.2"
 asyncpg = "^0.31.0"
 discord-py = "^2.6.4"
 httpx = {extras = ["http2"], version = "^0.28.1"}
+jinja2 = "^3.1.5"
 uvicorn = {extras = ["standard"], version = "^0.38.0"}
 pynacl = "^1.6.1"
 


### PR DESCRIPTION
### Motivation
- Provide a lightweight HTML landing page served by FastAPI to expose a simple UI for login and quick links to queue/session endpoints.
- Reuse the existing session cookie (`jukebotx_session`) and OAuth flow so the page can show guild links after login.
- Serve a minimal static stylesheet to keep the page presentable without adding frontend build steps.

### Description
- Added `apps/api/jukebotx_api/templates/index.html` and `apps/api/jukebotx_api/static/styles.css` to render a landing page with a `Login with Discord` link to `/auth/discord/login` and form/links to browse `/guilds/{guild_id}/queue` and session tracks.
- Wired Jinja2 into `apps/api/jukebotx_api/main.py` by mounting `StaticFiles` at `/static`, creating `Jinja2Templates`, adding a `GET /` route that reads the existing `jukebotx_session` cookie via `get_session_cookie` and `parse_session_cookie`, and passes `session`/`guild_ids` to the template.
- Added `jinja2` to `pyproject.toml` so templates can be rendered by Starlette/FastAPI.
- Kept existing OAuth/session helpers and routes unchanged and reused them from `apps/api/jukebotx_api/auth.py`.

### Testing
- Started the app locally with `PYTHONPATH=apps/api:packages/core:packages/infra python -m uvicorn jukebotx_api.main:app` and verified the server served the landing page at `GET /` by capturing a Playwright screenshot (succeeded).
- An initial `uvicorn` start without the package path failed due to missing local packages, which was resolved by including `PYTHONPATH` when launching the server.
- Attempted `poetry lock` to update the lockfile after adding `jinja2`, but it failed due to inability to reach `pypi.org` (network error).
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956e5cbcb74832f8c64c337a3e47cff)