### PR TITLE
feat(bot): add web session URL command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ DATABASE_URL=postgresql+asyncpg://jukebotx:jukebotx@db:5432/jukebotx
 DEV_DISCORD_TOKEN=xxxxxxxxxxxxxxxx
 DISCORD_TOKEN=yyyyyyyyyyyyyyyyyyyy
 DISCORD_GUILD_ID=123456789012345678
+WEB_BASE_URL=http://localhost:8001
 
 # API
 API_HOST=0.0.0.0

--- a/README.md
+++ b/README.md
@@ -291,6 +291,10 @@ The bot uses **prefix commands** with `;` (configured in `apps/bot/jukebotx_bot/
 * `;autoplay [count|off]` — auto-play up to `count` tracks or until empty (mod-only)
 * `;dj [count|off]` — DJ mode for `count` tracks or until empty (mod-only)
 
+### Web UI
+
+* `;web` / `;sessionurl` — post the session UI link (requires `WEB_BASE_URL`)
+
 ### Announcements
 
 * `;ping here <message>` — announce in the jam session channel (mod-only)

--- a/apps/bot/jukebotx_bot/main.py
+++ b/apps/bot/jukebotx_bot/main.py
@@ -429,6 +429,30 @@ class JukeBot(commands.Bot):
             session.submissions_open = False
             await ctx.send("Submissions are closed.")
 
+        @self.command(name="web", aliases=["sessionurl"])
+        async def web(ctx: commands.Context) -> None:
+            if ctx.guild is None:
+                await ctx.send("This command can only be used in a server.")
+                return
+
+            if self.settings.web_base_url is None:
+                await ctx.send("Web UI base URL is not configured.")
+                return
+
+            base_url = self.settings.web_base_url.rstrip("/")
+            url = (
+                f"{base_url}/guilds/{ctx.guild.id}"
+                f"/channels/{ctx.channel.id}/session/tracks"
+            )
+
+            target_channel = ctx.channel
+            if self.settings.jam_session_channel_id is not None:
+                configured_channel = ctx.guild.get_channel(self.settings.jam_session_channel_id)
+                if isinstance(configured_channel, discord.abc.Messageable):
+                    target_channel = configured_channel
+
+            await target_channel.send(f"Session URL: {url}")
+
         @self.command(name="playlist")
         async def playlist(ctx: commands.Context, url: str) -> None:
             if ctx.guild is None or not isinstance(ctx.author, discord.Member):

--- a/apps/bot/jukebotx_bot/settings.py
+++ b/apps/bot/jukebotx_bot/settings.py
@@ -26,6 +26,7 @@ class BotSettings(BaseSettings):
         default=None, alias="JAM_SESSION_CHANNEL_ID"
     )
     jam_session_role_id: int | None = Field(default=None, alias="JAM_SESSION_ROLE_ID")
+    web_base_url: str | None = Field(default=None, alias="WEB_BASE_URL")
 
     # Pydantic v2 configuration
     model_config = SettingsConfigDict(


### PR DESCRIPTION
### Motivation

- Provide an easy way for users to open the Web UI for the current guild/session from Discord.
- Allow posting the session link into a configured jam session channel for broader visibility.
- Make the Web UI base URL configurable via environment so deployments can point at different frontends.

### Description

- Add a new `web_base_url` setting (`WEB_BASE_URL`) to `apps/bot/jukebotx_bot/settings.py`.
- Implement a `;web` command (alias `;sessionurl`) in `apps/bot/jukebotx_bot/main.py` that validates guild context, builds the URL `{"{WEB_BASE_URL}/guilds/{guild_id}/channels/{channel_id}/session/tracks"}`, and posts it.
- If `JAM_SESSION_CHANNEL_ID` is configured, the command will post the URL to that channel instead of the invoking channel.
- Document the new env var in `.env.example` and add the command to the `README.md` commands section.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956ebccc994832fa58b58765a5f3941)