### PR TITLE
Unescape Suno meta tag content

### DIFF
--- a/packages/infra/jukebotx_infra/suno/client.py
+++ b/packages/infra/jukebotx_infra/suno/client.py
@@ -71,7 +71,7 @@ def _parse_meta_tags(page_html: str) -> dict[str, str]:
     tags: dict[str, str] = {}
     for m in _META_TAG_RE.finditer(page_html):
         key = m.group("key").strip()
-        val = m.group("val").strip()
+        val = html_lib.unescape(m.group("val").strip())
         if key and val:
             tags[key] = val
     return tags

--- a/tests/test_suno_client_meta.py
+++ b/tests/test_suno_client_meta.py
@@ -1,0 +1,30 @@
+from jukebotx_infra.suno.client import SunoTrackData, _parse_meta_tags, _parse_title_artist_from_description
+
+
+def test_parse_meta_tags_unescapes_description_title() -> None:
+    page_html = """
+    <html>
+      <head>
+        <meta name="description" content="Pixel Fighter&#x27;s by DJ Example. Listen and make your own on Suno. (@djexample)">
+        <meta property="og:description" content="Pixel Fighter&#x27;s by DJ Example. Listen and make your own on Suno. (@djexample)">
+      </head>
+      <body></body>
+    </html>
+    """
+
+    meta = _parse_meta_tags(page_html)
+    description = meta.get("description") or meta.get("og:description")
+    title, artist_display, artist_username = _parse_title_artist_from_description(description)
+
+    track = SunoTrackData(
+        suno_url="https://suno.com/song/example",
+        title=title,
+        artist_display=artist_display,
+        artist_username=artist_username,
+        lyrics=None,
+        image_url=None,
+        video_url=None,
+        mp3_url=None,
+    )
+
+    assert track.title == "Pixel Fighter's"


### PR DESCRIPTION
### Motivation
- Suno meta tag `content` values were being stored with HTML entities still escaped, causing downstream fields like `description` and `og:*` to contain entities instead of characters.
- The escaped values could propagate into parsed `title` and `artist_display` values, producing incorrect display names like `Pixel Fighter&#x27;s`.
- Normalize and unescape meta content early so parsed metadata and resulting `SunoTrackData` fields contain readable text.

### Description
- HTML-unescape meta tag `content` values by applying `html_lib.unescape(...)` in `_parse_meta_tags` before storing.
- Ensure unescaped values are used when selecting `description` / `og:description` so parsing flows into `title` and `artist_display`.
- Add a focused unit test `tests/test_suno_client_meta.py` that asserts `"Pixel Fighter&#x27;s"` becomes `"Pixel Fighter's"` when parsed into `SunoTrackData.title`.

### Testing
- Added unit test `tests/test_suno_client_meta.py` that exercises `_parse_meta_tags` and `_parse_title_artist_from_description` and asserts expected unescaping.
- No automated test suite was executed as part of this change (the test file was added but not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959b19dd954832fb1658ec51c17ee6f)