### PR TITLE
Preserve periods in artist names when trimming Suno promo text

### DIFF
--- a/packages/infra/jukebotx_infra/suno/client.py
+++ b/packages/infra/jukebotx_infra/suno/client.py
@@ -246,8 +246,10 @@ def _parse_title_artist_from_description(description: str | None) -> tuple[str |
 
     # Trim promo sentence if present
     promo = "listen and make your own on suno"
-    if promo in right.lower():
-        right = right.split(".", 1)[0].strip()
+    lowered_right = right.lower()
+    promo_index = lowered_right.find(promo)
+    if promo_index != -1:
+        right = right[:promo_index].rstrip(" .").strip()
 
     artist_display = right.strip() or None
     return song_title, artist_display, artist_username

--- a/tests/test_suno_client_meta.py
+++ b/tests/test_suno_client_meta.py
@@ -28,3 +28,13 @@ def test_parse_meta_tags_unescapes_description_title() -> None:
     )
 
     assert track.title == "Pixel Fighter's"
+
+
+def test_parse_title_artist_preserves_periods_before_promo() -> None:
+    description = "Track Title by Mr.Finnish. Listen and make your own on Suno"
+
+    title, artist_display, artist_username = _parse_title_artist_from_description(description)
+
+    assert title == "Track Title"
+    assert artist_display == "Mr.Finnish"
+    assert artist_username is None


### PR DESCRIPTION
### Motivation
- Avoid truncating artist display names that contain periods when removing Suno's promo text.
- The previous logic used `right.split(".", 1)[0]` which cut off names like `Mr.Finnish`.
- Trim only the promo phrase (`"listen and make your own on suno"`) so internal punctuation in artist names is preserved.
- Add a regression test to cover artists with periods before the promo phrase.

### Description
- Update `_parse_title_artist_from_description` to locate the promo phrase case-insensitively with `str.find` and slice up to that index instead of splitting on the first period.
- Use `promo_index = lowered_right.find(promo)` and `right = right[:promo_index].rstrip(" .").strip()` when the promo is present.
- Remove the previous `right.split(".", 1)[0]` approach.
- Add `test_parse_title_artist_preserves_periods_before_promo` to `tests/test_suno_client_meta.py` to assert that `"Mr.Finnish"` is preserved.

### Testing
- Ran `pytest -q tests/test_suno_client_meta.py` to exercise the updated parsing and new test.
- Test collection failed with `ModuleNotFoundError: No module named 'jukebotx_infra'` in the current test environment, so tests did not complete successfully.
- Changes are committed locally (`Adjust Suno promo trimming`).
- The new unit test demonstrates the intended behavior when run in a properly configured environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959b2a6124c832f9332996b42b71fb5)