### PR TITLE
Adjust queue header based on size

### DIFF
--- a/apps/bot/jukebotx_bot/main.py
+++ b/apps/bot/jukebotx_bot/main.py
@@ -592,7 +592,13 @@ class JukeBot(commands.Bot):
             lines: list[str] = []
 
             if session.queue:
-                lines.append("Up next:")
+                total = len(session.queue)
+                if total == 1:
+                    lines.append("Last song")
+                elif total > 5:
+                    lines.append(f"Next 5 out of {total}")
+                else:
+                    lines.append(f"Next {total}")
                 for idx, track in enumerate(session.queue[:5], start=1):
                     lines.append(f"{idx}. {track.title} (requested by {track.requester_name})")
             else:


### PR DESCRIPTION
### Motivation
- Improve the `;q` command output to better reflect how many tracks remain in the queue when listing upcoming songs.
- Provide clearer messaging for single-item, small, and long queues so users know whether the list is complete or truncated.

### Description
- Replace the static header `"Up next:"` with conditional logic using `total = len(session.queue)` in `apps/bot/jukebotx_bot/main.py`.
- Append `"Last song"` when `total == 1`, `f"Next 5 out of {total}"` when `total > 5`, and `f"Next {total}"` otherwise.
- Keep the list rendering `session.queue[:5]` unchanged so only up to five items are displayed.
- Updated the `queue` command handler accordingly.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959b657fba4832fbb1f8596c5d7ffb0)