### PR TITLE
Tailor queue prompt for mod playlist access

### DIFF
--- a/apps/bot/jukebotx_bot/main.py
+++ b/apps/bot/jukebotx_bot/main.py
@@ -590,6 +590,14 @@ class JukeBot(commands.Bot):
 
             session = self._get_session(ctx).for_guild(ctx.guild.id)
             lines: list[str] = []
+            if session.submissions_open:
+                lines.append("Session is open.")
+                if isinstance(ctx.author, discord.Member) and _is_mod(ctx.author):
+                    lines.append("Add a Suno URL to queue a song, or use `;playlist <url>`.")
+                else:
+                    lines.append("Add a Suno URL to queue a song.")
+            else:
+                lines.append("Session is closed.")
 
             if session.queue:
                 total = len(session.queue)


### PR DESCRIPTION
### Motivation
- Make the current submission state visible when running `;q` so users know whether submissions are open or closed.
- Avoid advertising the `;playlist` command to users who cannot use it, since only moderators may invoke `;playlist`.

### Description
- Updated `apps/bot/jukebotx_bot/main.py` in the `@self.command(name="q")` handler to prepend a status line reflecting `session.submissions_open`.
- When submissions are open, append a Suno URL prompt and only include the `;playlist <url>` guidance if `isinstance(ctx.author, discord.Member)` and `_is_mod(ctx.author)` return true.
- Kept the closed-session messaging unchanged and joined the built `lines` list into the final `ctx.send` output.

### Testing
- No automated tests were run for this change.
- (No CI/test results to report.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959bf2d100c832fad1b24ae430dbf19)