### PR TITLE
Show playlist hint to mods in play (`;p`) empty-queue messages

### DIFF
--- a/apps/bot/jukebotx_bot/main.py
+++ b/apps/bot/jukebotx_bot/main.py
@@ -642,12 +642,22 @@ class JukeBot(commands.Bot):
                 return
 
             if not session.queue:
-                await ctx.send("Queue is empty. Drop a Suno URL or use ;playlist <Suno Playlist URL>.")
+                if isinstance(ctx.author, discord.Member) and _is_mod(ctx.author):
+                    await ctx.send(
+                        "Queue is empty. Drop a Suno URL or use ;playlist <Suno Playlist URL>."
+                    )
+                else:
+                    await ctx.send("Queue is empty. Drop a Suno URL.")
                 return
 
             started = await audio.play_next(ctx.voice_client)
             if started is None:
-                await ctx.send("Queue is empty. Drop a Suno URL or use ;playlist <Suno Playlist URL>.")
+                if isinstance(ctx.author, discord.Member) and _is_mod(ctx.author):
+                    await ctx.send(
+                        "Queue is empty. Drop a Suno URL or use ;playlist <Suno Playlist URL>."
+                    )
+                else:
+                    await ctx.send("Queue is empty. Drop a Suno URL.")
                 return
 
             session.now_playing_channel_id = ctx.channel.id


### PR DESCRIPTION
### Motivation
- Align the `;p` command empty-queue messaging with the existing `;q` command behavior.
- Only show the `;playlist` hint to moderators to avoid confusing non-mod users.
- Keep the moderator check consistent with the existing `_is_mod` helper.

### Description
- Update `apps/bot/jukebotx_bot/main.py` in the `@self.command(name="p")` handler to conditionalize the empty-queue responses.
- Replace the two static empty-queue responses with a check for `isinstance(ctx.author, discord.Member) and _is_mod(ctx.author)` and send the playlist hint only for mods.
- Preserve the original non-mod message text (`"Queue is empty. Drop a Suno URL."`) for non-moderators.

### Testing
- No automated tests were run against this change.
- The patch was applied and committed successfully to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959c27138f4832fb8bab654e77a85a7)