### PR TITLE
Include DJ and Master of Ceremonies in mod role checks

### DIFF
--- a/apps/bot/jukebotx_bot/main.py
+++ b/apps/bot/jukebotx_bot/main.py
@@ -31,9 +31,13 @@ from jukebotx_infra.suno.playlist_client import HttpxSunoPlaylistClient
 
 
 def _is_mod(member: discord.Member) -> bool:
-    """Return True if the member has server-level moderation permissions."""
+    """Return True if the member has moderation permissions or an allowed role."""
     perms = member.guild_permissions
-    return bool(perms.administrator or perms.manage_guild)
+    if perms.administrator or perms.manage_guild:
+        return True
+
+    allowed_roles = {"admin", "mod", "master of ceremonies", "dj"}
+    return any(role.name.lower() in allowed_roles for role in member.roles)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
### Motivation
- Treat role names for `Master of Ceremonies` and `DJ` as equivalent to existing `Mod`/`Admin` roles so they can access mod-only commands.
- Keep existing server-permission checks so administrators and guild managers still bypass role checks.

### Description
- Update `def _is_mod` in `apps/bot/jukebotx_bot/main.py` to also check member role names.
- Add an `allowed_roles` set that includes `"admin"`, `"mod"`, `"master of ceremonies"`, and `"dj"` and perform a case-insensitive match against `role.name`.
- Preserve the early return for `administrator` and `manage_guild` permissions.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c6407b294832fae0df06c31c73de4)