### PR TITLE
Add jam session models, session-scoped queue & reactions, and Alembic baseline

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = postgresql://jukebotx:jukebotx@localhost:5432/jukebotx
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import os
+import sys
+from logging.config import fileConfig
+from pathlib import Path
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "packages" / "infra"))
+
+from jukebotx_infra.db.models import Base
+
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def _get_url() -> str:
+    url = os.getenv("DATABASE_URL", config.get_main_option("sqlalchemy.url"))
+    if url.startswith("postgresql+asyncpg"):
+        url = url.replace("postgresql+asyncpg", "postgresql", 1)
+    return url
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=_get_url(),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+        url=_get_url(),
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,25 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+${imports if imports else ""}
+
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/0001_initial.py
+++ b/alembic/versions/0001_initial.py
@@ -1,0 +1,174 @@
+"""Initial schema.
+
+Revision ID: 0001_initial
+Revises: 
+Create Date: 2025-01-10 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0001_initial"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tracks",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("suno_url", sa.String(length=512), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=True),
+        sa.Column("artist_display", sa.String(length=255), nullable=True),
+        sa.Column("artist_username", sa.String(length=255), nullable=True),
+        sa.Column("lyrics", sa.Text(), nullable=True),
+        sa.Column("image_url", sa.String(length=1024), nullable=True),
+        sa.Column("video_url", sa.String(length=1024), nullable=True),
+        sa.Column("mp3_url", sa.String(length=1024), nullable=True),
+        sa.Column("opus_url", sa.String(length=1024), nullable=True),
+        sa.Column("opus_path", sa.String(length=1024), nullable=True),
+        sa.Column("opus_status", sa.String(length=32), nullable=True),
+        sa.Column("opus_transcoded_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("suno_url", name="uq_tracks_suno_url"),
+    )
+    op.create_index("ix_tracks_suno_url", "tracks", ["suno_url"], unique=True)
+
+    op.create_table(
+        "jam_sessions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("guild_id", sa.BigInteger(), nullable=False),
+        sa.Column("channel_id", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum("active", "ended", name="jam_session_status"),
+            nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("ended_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_jam_sessions_channel_id", "jam_sessions", ["channel_id"], unique=False)
+    op.create_index("ix_jam_sessions_guild_id", "jam_sessions", ["guild_id"], unique=False)
+    op.create_index("ix_jam_sessions_status", "jam_sessions", ["status"], unique=False)
+    op.create_index(
+        "ix_jam_sessions_active_guild",
+        "jam_sessions",
+        ["guild_id"],
+        unique=True,
+        postgresql_where=sa.text("ended_at IS NULL"),
+    )
+
+    op.create_table(
+        "submissions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("track_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("guild_id", sa.BigInteger(), nullable=False),
+        sa.Column("channel_id", sa.BigInteger(), nullable=False),
+        sa.Column("message_id", sa.BigInteger(), nullable=False),
+        sa.Column("author_id", sa.BigInteger(), nullable=False),
+        sa.Column("submitted_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["track_id"], ["tracks.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_submissions_guild_id", "submissions", ["guild_id"], unique=False)
+
+    op.create_table(
+        "queue_items",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("guild_id", sa.BigInteger(), nullable=False),
+        sa.Column("session_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("track_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("requested_by", sa.BigInteger(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("position", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["session_id"], ["jam_sessions.id"]),
+        sa.ForeignKeyConstraint(["track_id"], ["tracks.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_queue_items_guild_id", "queue_items", ["guild_id"], unique=False)
+    op.create_index("ix_queue_items_session_id", "queue_items", ["session_id"], unique=False)
+    op.create_index("ix_queue_items_status", "queue_items", ["status"], unique=False)
+
+    op.create_table(
+        "session_reactions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("session_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("track_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "reaction_type",
+            sa.Enum("upvote", "downvote", name="session_reaction_type"),
+            nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["session_id"], ["jam_sessions.id"]),
+        sa.ForeignKeyConstraint(["track_id"], ["tracks.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "session_id",
+            "track_id",
+            "user_id",
+            "reaction_type",
+            name="uq_session_reactions_unique",
+        ),
+    )
+    op.create_index("ix_session_reactions_session_id", "session_reactions", ["session_id"], unique=False)
+    op.create_index("ix_session_reactions_track_id", "session_reactions", ["track_id"], unique=False)
+    op.create_index("ix_session_reactions_reaction_type", "session_reactions", ["reaction_type"], unique=False)
+
+    op.create_table(
+        "opus_jobs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("track_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("mp3_url", sa.String(length=1024), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["track_id"], ["tracks.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("track_id", name="uq_opus_jobs_track_id"),
+    )
+    op.create_index("ix_opus_jobs_status", "opus_jobs", ["status"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_opus_jobs_status", table_name="opus_jobs")
+    op.drop_table("opus_jobs")
+
+    op.drop_index("ix_session_reactions_reaction_type", table_name="session_reactions")
+    op.drop_index("ix_session_reactions_track_id", table_name="session_reactions")
+    op.drop_index("ix_session_reactions_session_id", table_name="session_reactions")
+    op.drop_table("session_reactions")
+
+    op.drop_index("ix_queue_items_status", table_name="queue_items")
+    op.drop_index("ix_queue_items_session_id", table_name="queue_items")
+    op.drop_index("ix_queue_items_guild_id", table_name="queue_items")
+    op.drop_table("queue_items")
+
+    op.drop_index("ix_submissions_guild_id", table_name="submissions")
+    op.drop_table("submissions")
+
+    op.drop_index("ix_jam_sessions_active_guild", table_name="jam_sessions")
+    op.drop_index("ix_jam_sessions_status", table_name="jam_sessions")
+    op.drop_index("ix_jam_sessions_guild_id", table_name="jam_sessions")
+    op.drop_index("ix_jam_sessions_channel_id", table_name="jam_sessions")
+    op.drop_table("jam_sessions")
+
+    op.drop_index("ix_tracks_suno_url", table_name="tracks")
+    op.drop_table("tracks")
+
+    op.execute("DROP TYPE IF EXISTS session_reaction_type")
+    op.execute("DROP TYPE IF EXISTS jam_session_status")

--- a/apps/bot/jukebotx_bot/main.py
+++ b/apps/bot/jukebotx_bot/main.py
@@ -405,7 +405,7 @@ class JukeBot(commands.Bot):
                 await audio.stop(ctx.voice_client)
                 await ctx.voice_client.disconnect()
 
-            await self.deps.queue_repo.clear(guild_id=ctx.guild.id)
+            await self.deps.queue_repo.clear(guild_id=ctx.guild.id, session_id=None)
             await self.deps.submission_repo.clear_for_channel(
                 guild_id=ctx.guild.id,
                 channel_id=ctx.channel.id,

--- a/packages/core/jukebotx_core/use_cases/clear_queue.py
+++ b/packages/core/jukebotx_core/use_cases/clear_queue.py
@@ -1,6 +1,8 @@
 # packages/core/jukebotx_core/use_cases/clear_queue.py
 from __future__ import annotations
 
+from uuid import UUID
+
 from jukebotx_core.ports.repositories import QueueRepository
 
 
@@ -12,5 +14,5 @@ class ClearQueue:
     def __init__(self, *, queue_repo: QueueRepository) -> None:
         self._queue_repo = queue_repo
 
-    async def execute(self, *, guild_id: int) -> None:
-        await self._queue_repo.clear(guild_id=guild_id)
+    async def execute(self, *, guild_id: int, session_id: UUID | None = None) -> None:
+        await self._queue_repo.clear(guild_id=guild_id, session_id=session_id)

--- a/packages/core/jukebotx_core/use_cases/get_next_track.py
+++ b/packages/core/jukebotx_core/use_cases/get_next_track.py
@@ -22,8 +22,8 @@ class GetNextTrack:
         self._queue_repo = queue_repo
         self._track_repo = track_repo
 
-    async def execute(self, *, guild_id: int) -> NextTrackResult | None:
-        qi = await self._queue_repo.get_next_unplayed(guild_id=guild_id)
+    async def execute(self, *, guild_id: int, session_id: UUID | None = None) -> NextTrackResult | None:
+        qi = await self._queue_repo.get_next_unplayed(guild_id=guild_id, session_id=session_id)
         if qi is None:
             return None
 

--- a/packages/core/jukebotx_core/use_cases/get_queue_preview.py
+++ b/packages/core/jukebotx_core/use_cases/get_queue_preview.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from uuid import UUID
 
 from jukebotx_core.ports.repositories import QueueItem, QueueRepository
 
@@ -19,6 +20,6 @@ class GetQueuePreview:
     def __init__(self, *, queue_repo: QueueRepository) -> None:
         self._queue_repo = queue_repo
 
-    async def execute(self, *, guild_id: int, limit: int = 5) -> QueuePreviewResult:
-        items = await self._queue_repo.preview(guild_id=guild_id, limit=limit)
+    async def execute(self, *, guild_id: int, session_id: UUID | None = None, limit: int = 5) -> QueuePreviewResult:
+        items = await self._queue_repo.preview(guild_id=guild_id, session_id=session_id, limit=limit)
         return QueuePreviewResult(items=items)

--- a/packages/core/jukebotx_core/use_cases/ingest_suno_links.py
+++ b/packages/core/jukebotx_core/use_cases/ingest_suno_links.py
@@ -22,6 +22,7 @@ class IngestSunoLinkInput:
     message_id: int
     author_id: int
     suno_url: str
+    session_id: UUID | None = None
     auto_enqueue: bool = False
 
 
@@ -108,6 +109,7 @@ class IngestSunoLink:
                     guild_id=data.guild_id,
                     track_id=track.id,
                     requested_by=data.author_id,
+                    session_id=data.session_id,
                 )
             )
             queued = True

--- a/packages/core/jukebotx_core/use_cases/mark_track_played.py
+++ b/packages/core/jukebotx_core/use_cases/mark_track_played.py
@@ -14,5 +14,5 @@ class MarkTrackPlayed:
     def __init__(self, *, queue_repo: QueueRepository) -> None:
         self._queue_repo = queue_repo
 
-    async def execute(self, *, guild_id: int, queue_item_id: UUID) -> None:
-        await self._queue_repo.mark_played(guild_id=guild_id, queue_item_id=queue_item_id)
+    async def execute(self, *, guild_id: int, queue_item_id: UUID, session_id: UUID | None = None) -> None:
+        await self._queue_repo.mark_played(guild_id=guild_id, session_id=session_id, queue_item_id=queue_item_id)

--- a/packages/infra/jukebotx_infra/repos/__init__.py
+++ b/packages/infra/jukebotx_infra/repos/__init__.py
@@ -1,6 +1,15 @@
+from jukebotx_infra.repos.jam_session_repo import PostgresJamSessionRepository
+from jukebotx_infra.repos.opus_job_repo import PostgresOpusJobRepository
 from jukebotx_infra.repos.queue_repo import PostgresQueueRepository
+from jukebotx_infra.repos.session_reaction_repo import PostgresSessionReactionRepository
 from jukebotx_infra.repos.submission_repo import PostgresSubmissionRepository
 from jukebotx_infra.repos.track_repo import PostgresTrackRepository
-from jukebotx_infra.repos.opus_job_repo import PostgresOpusJobRepository
 
-__all__ = ["PostgresQueueRepository", "PostgresSubmissionRepository", "PostgresTrackRepository", "PostgresOpusJobRepository"]
+__all__ = [
+    "PostgresJamSessionRepository",
+    "PostgresQueueRepository",
+    "PostgresSessionReactionRepository",
+    "PostgresSubmissionRepository",
+    "PostgresTrackRepository",
+    "PostgresOpusJobRepository",
+]

--- a/packages/infra/jukebotx_infra/repos/jam_session_repo.py
+++ b/packages/infra/jukebotx_infra/repos/jam_session_repo.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from jukebotx_core.ports.repositories import JamSession, JamSessionCreate, JamSessionRepository, JamSessionStatus
+from jukebotx_infra.db.models import JamSessionModel, JamSessionStatus as JamSessionStatusModel
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _to_domain(session: JamSessionModel) -> JamSession:
+    return JamSession(
+        id=session.id,
+        guild_id=session.guild_id,
+        channel_id=session.channel_id,
+        status=JamSessionStatus(session.status.value),
+        created_at=session.created_at,
+        updated_at=session.updated_at,
+        ended_at=session.ended_at,
+    )
+
+
+class PostgresJamSessionRepository(JamSessionRepository):
+    def __init__(self, session_factory: async_sessionmaker) -> None:
+        self._session_factory = session_factory
+
+    async def create(self, data: JamSessionCreate) -> JamSession:
+        async with self._session_factory() as session:
+            now = _now()
+            created = JamSessionModel(
+                guild_id=data.guild_id,
+                channel_id=data.channel_id,
+                status=JamSessionStatusModel(data.status.value),
+                created_at=now,
+                updated_at=now,
+            )
+            session.add(created)
+            await session.commit()
+            await session.refresh(created)
+            return _to_domain(created)
+
+    async def get_by_id(self, *, session_id: UUID) -> JamSession | None:
+        async with self._session_factory() as session:
+            result = await session.get(JamSessionModel, session_id)
+            return _to_domain(result) if result else None
+
+    async def get_active_for_guild(self, *, guild_id: int) -> JamSession | None:
+        async with self._session_factory() as session:
+            result = await session.scalar(
+                select(JamSessionModel).where(
+                    JamSessionModel.guild_id == guild_id,
+                    JamSessionModel.ended_at.is_(None),
+                )
+            )
+            return _to_domain(result) if result else None
+
+    async def end(self, *, session_id: UUID) -> JamSession:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                update(JamSessionModel)
+                .where(JamSessionModel.id == session_id)
+                .values(
+                    status=JamSessionStatusModel.ENDED,
+                    ended_at=_now(),
+                    updated_at=_now(),
+                )
+                .returning(JamSessionModel)
+            )
+            row = result.scalar_one_or_none()
+            await session.commit()
+            if row is None:
+                raise KeyError(f"Jam session not found: {session_id}")
+            return _to_domain(row)

--- a/packages/infra/jukebotx_infra/repos/session_reaction_repo.py
+++ b/packages/infra/jukebotx_infra/repos/session_reaction_repo.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from jukebotx_core.ports.repositories import (
+    SessionReaction,
+    SessionReactionCreate,
+    SessionReactionRepository,
+    SessionReactionType,
+)
+from jukebotx_infra.db.models import SessionReactionModel, SessionReactionType as SessionReactionTypeModel
+
+
+def _to_domain(reaction: SessionReactionModel) -> SessionReaction:
+    return SessionReaction(
+        id=reaction.id,
+        session_id=reaction.session_id,
+        track_id=reaction.track_id,
+        user_id=reaction.user_id,
+        reaction_type=SessionReactionType(reaction.reaction_type.value),
+        created_at=reaction.created_at,
+    )
+
+
+class PostgresSessionReactionRepository(SessionReactionRepository):
+    def __init__(self, session_factory: async_sessionmaker) -> None:
+        self._session_factory = session_factory
+
+    async def add(self, data: SessionReactionCreate) -> SessionReaction:
+        async with self._session_factory() as session:
+            created = SessionReactionModel(
+                session_id=data.session_id,
+                track_id=data.track_id,
+                user_id=data.user_id,
+                reaction_type=SessionReactionTypeModel(data.reaction_type.value),
+            )
+            session.add(created)
+            await session.commit()
+            await session.refresh(created)
+            return _to_domain(created)
+
+    async def list_for_session(self, *, session_id: UUID) -> list[SessionReaction]:
+        async with self._session_factory() as session:
+            rows = await session.scalars(
+                select(SessionReactionModel).where(SessionReactionModel.session_id == session_id)
+            )
+            return [_to_domain(row) for row in rows]
+
+    async def remove(
+        self,
+        *,
+        session_id: UUID,
+        track_id: UUID,
+        user_id: int,
+        reaction_type: SessionReactionType,
+    ) -> None:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                delete(SessionReactionModel).where(
+                    SessionReactionModel.session_id == session_id,
+                    SessionReactionModel.track_id == track_id,
+                    SessionReactionModel.user_id == user_id,
+                    SessionReactionModel.reaction_type == SessionReactionTypeModel(reaction_type.value),
+                )
+            )
+            await session.commit()
+            if result.rowcount == 0:
+                raise KeyError("Session reaction not found.")

--- a/tests/test_suno_ingest.py
+++ b/tests/test_suno_ingest.py
@@ -39,7 +39,9 @@ async def cleanup_db(async_session_factory: async_sessionmaker) -> None:
     yield
     async with async_session_factory() as session:
         await session.execute(
-            text("TRUNCATE TABLE queue_items, submissions, tracks RESTART IDENTITY CASCADE")
+            text(
+                "TRUNCATE TABLE session_reactions, queue_items, submissions, jam_sessions, tracks RESTART IDENTITY CASCADE"
+            )
         )
         await session.commit()
 


### PR DESCRIPTION
### Motivation
- Introduce a first-class jam session concept to model session lifecycle and scope session-specific data.  
- Support per-session reactions (upvote/downvote) against session tracks with uniqueness constraints.  
- Allow queue items to be optionally tied to a session so queues can be scoped per-session or global.  
- Provide Alembic setup and a baseline migration so the schema can be managed in dev/prod environments.

### Description
- Added `JamSessionModel`, `SessionReactionModel`, `JamSessionStatus` and `SessionReactionType` to `packages/infra/jukebotx_infra/db/models.py` and added `session_id` (UUID FK) to `QueueItemModel` with indexes/unique constraints matching the plan.  
- Extended core repository ports in `packages/core/jukebotx_core/ports/repositories.py` with session-aware types (`session_id` on `QueueItem`/`QueueItemCreate`), jam session and reaction dataclasses and repositories interfaces.  
- Implemented Postgres-backed repositories: `PostgresJamSessionRepository` and `PostgresSessionReactionRepository` in `packages/infra/jukebotx_infra/repos/`, and updated `PostgresQueueRepository` and in-memory repo to handle optional `session_id`.  
- Added Alembic configuration (`alembic.ini`, `alembic/env.py`, `alembic/script.py.mako`) and an initial migration `alembic/versions/0001_initial.py`, and updated API/bot call sites and test cleanup to be session-aware.

### Testing
- No automated test suite was executed as part of this change.  
- Updated `tests/test_suno_ingest.py` to truncate the new tables during test cleanup (no test run performed).  
- The new Alembic configuration and migration were added as a baseline and should be applied in a dev DB to validate schema creation.  
- Manual or CI test runs are recommended to validate repository behavior and endpoint changes against a Postgres instance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cb5973434832fbf6470cd6363693f)