### PR TITLE
Add Discord Activity exchange endpoint and JWT auth support

### DIFF
--- a/apps/api/jukebotx_api/auth.py
+++ b/apps/api/jukebotx_api/auth.py
@@ -9,7 +9,8 @@ import json
 import secrets
 from typing import Any
 
-from fastapi import Depends, HTTPException, Request
+from fastapi import Depends, HTTPException, Request, WebSocket
+from fastapi.websockets import WebSocketException
 from fastapi.responses import RedirectResponse, Response
 import httpx
 
@@ -35,6 +36,7 @@ class SessionData:
 OAUTH_AUTHORIZE_URL = "https://discord.com/api/oauth2/authorize"
 OAUTH_TOKEN_URL = "https://discord.com/api/oauth2/token"
 DISCORD_API_BASE = "https://discord.com/api"
+JWT_ALGORITHM = "HS256"
 
 
 def _b64encode(data: bytes) -> str:
@@ -125,6 +127,121 @@ def clear_session(response: Response) -> None:
     response.delete_cookie("jukebotx_session")
 
 
+def _encode_jwt(payload: dict[str, Any], secret: str) -> str:
+    header = {"alg": JWT_ALGORITHM, "typ": "JWT"}
+    header_b64 = _b64encode(json.dumps(header, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+    payload_b64 = _b64encode(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+    signing_input = f"{header_b64}.{payload_b64}".encode("utf-8")
+    signature = hmac.new(secret.encode("utf-8"), signing_input, hashlib.sha256).digest()
+    return f"{header_b64}.{payload_b64}.{_b64encode(signature)}"
+
+
+def _decode_jwt(token: str, secret: str) -> dict[str, Any] | None:
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+    header_b64, payload_b64, signature_b64 = parts
+    signing_input = f"{header_b64}.{payload_b64}".encode("utf-8")
+    expected_signature = hmac.new(secret.encode("utf-8"), signing_input, hashlib.sha256).digest()
+    if not hmac.compare_digest(_b64encode(expected_signature), signature_b64):
+        return None
+    try:
+        header = json.loads(_b64decode(header_b64))
+        payload = json.loads(_b64decode(payload_b64))
+    except json.JSONDecodeError:
+        return None
+    if header.get("alg") != JWT_ALGORITHM:
+        return None
+    exp_value = payload.get("exp")
+    if exp_value is not None:
+        try:
+            exp = datetime.fromtimestamp(float(exp_value), tz=timezone.utc)
+        except (TypeError, ValueError):
+            return None
+        if datetime.now(timezone.utc) >= exp:
+            return None
+    return payload
+
+
+def create_api_jwt(session: SessionData, secret: str, ttl_seconds: int) -> str:
+    now = datetime.now(timezone.utc)
+    payload = {
+        "sub": session.user_id,
+        "username": session.username,
+        "discriminator": session.discriminator,
+        "avatar": session.avatar,
+        "guild_ids": session.guild_ids,
+        "iat": int(now.timestamp()),
+        "exp": int((now + timedelta(seconds=ttl_seconds)).timestamp()),
+    }
+    return _encode_jwt(payload, secret)
+
+
+def parse_api_jwt(token: str, secret: str) -> SessionData | None:
+    payload = _decode_jwt(token, secret)
+    if payload is None:
+        return None
+    try:
+        issued_at = datetime.fromtimestamp(float(payload["iat"]), tz=timezone.utc)
+    except (KeyError, TypeError, ValueError):
+        return None
+    return SessionData(
+        user_id=str(payload.get("sub", "")),
+        username=str(payload.get("username", "")),
+        discriminator=payload.get("discriminator"),
+        avatar=payload.get("avatar"),
+        guild_ids=[str(gid) for gid in payload.get("guild_ids", [])],
+        issued_at=issued_at,
+    )
+
+
+def _get_bearer_token(value: str | None) -> str | None:
+    if not value:
+        return None
+    scheme, _, token = value.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        return None
+    return token
+
+
+def _extract_token_from_request(request: Request) -> str | None:
+    header_token = _get_bearer_token(request.headers.get("Authorization"))
+    if header_token:
+        return header_token
+    return request.query_params.get("access_token")
+
+
+def _extract_token_from_websocket(websocket: WebSocket) -> str | None:
+    header_token = _get_bearer_token(websocket.headers.get("Authorization"))
+    if header_token:
+        return header_token
+    return websocket.query_params.get("access_token")
+
+
+def ensure_jwt_configured(settings: ApiSettings) -> None:
+    if not settings.jwt_secret:
+        raise HTTPException(status_code=500, detail="API JWT secret is not configured.")
+
+
+def ensure_activity_oauth_configured(settings: ApiSettings) -> tuple[str, str, str | None]:
+    client_id = settings.discord_activity_client_id or settings.discord_client_id
+    client_secret = settings.discord_activity_client_secret or settings.discord_client_secret
+    redirect_uri = settings.discord_activity_redirect_uri or settings.discord_redirect_uri
+    missing = [
+        name
+        for name, value in {
+            "DISCORD_ACTIVITY_CLIENT_ID": client_id,
+            "DISCORD_ACTIVITY_CLIENT_SECRET": client_secret,
+            "API_JWT_SECRET": settings.jwt_secret,
+        }.items()
+        if not value
+    ]
+    if missing:
+        missing_list = ", ".join(missing)
+        raise HTTPException(status_code=500, detail=f"Activity configuration incomplete: {missing_list}")
+    return client_id, client_secret, redirect_uri or None
+
+
 async def exchange_code_for_token(code: str, settings: ApiSettings) -> dict[str, Any]:
     data = {
         "client_id": settings.discord_client_id,
@@ -133,6 +250,23 @@ async def exchange_code_for_token(code: str, settings: ApiSettings) -> dict[str,
         "code": code,
         "redirect_uri": settings.discord_redirect_uri,
     }
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.post(OAUTH_TOKEN_URL, data=data, headers=headers)
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def exchange_activity_proof(proof: str, settings: ApiSettings) -> dict[str, Any]:
+    client_id, client_secret, redirect_uri = ensure_activity_oauth_configured(settings)
+    data = {
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "grant_type": "authorization_code",
+        "code": proof,
+    }
+    if redirect_uri:
+        data["redirect_uri"] = redirect_uri
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
     async with httpx.AsyncClient(timeout=10.0) as client:
         resp = await client.post(OAUTH_TOKEN_URL, data=data, headers=headers)
@@ -205,4 +339,52 @@ def require_session(
         raise HTTPException(status_code=401, detail="Session expired.")
     if settings.discord_required_guild_id and settings.discord_required_guild_id not in session.guild_ids:
         raise HTTPException(status_code=403, detail="Not in required guild.")
+    return session
+
+
+def require_api_jwt(
+    request: Request,
+    settings: ApiSettings = Depends(load_api_settings),
+) -> SessionData:
+    ensure_jwt_configured(settings)
+    token = _extract_token_from_request(request)
+    if not token:
+        raise HTTPException(status_code=401, detail="Missing bearer token.")
+    session = parse_api_jwt(token, settings.jwt_secret)
+    if session is None:
+        raise HTTPException(status_code=401, detail="Invalid or expired token.")
+    if settings.discord_required_guild_id and settings.discord_required_guild_id not in session.guild_ids:
+        raise HTTPException(status_code=403, detail="Not in required guild.")
+    return session
+
+
+def require_api_auth(
+    request: Request,
+    settings: ApiSettings = Depends(load_api_settings),
+) -> SessionData:
+    token = _extract_token_from_request(request)
+    if token:
+        ensure_jwt_configured(settings)
+        session = parse_api_jwt(token, settings.jwt_secret)
+        if session is None:
+            raise HTTPException(status_code=401, detail="Invalid or expired token.")
+        if settings.discord_required_guild_id and settings.discord_required_guild_id not in session.guild_ids:
+            raise HTTPException(status_code=403, detail="Not in required guild.")
+        return session
+    return require_session(request=request, settings=settings)
+
+
+def require_api_jwt_websocket(
+    websocket: WebSocket,
+    settings: ApiSettings = Depends(load_api_settings),
+) -> SessionData:
+    ensure_jwt_configured(settings)
+    token = _extract_token_from_websocket(websocket)
+    if not token:
+        raise WebSocketException(code=1008)
+    session = parse_api_jwt(token, settings.jwt_secret)
+    if session is None:
+        raise WebSocketException(code=1008)
+    if settings.discord_required_guild_id and settings.discord_required_guild_id not in session.guild_ids:
+        raise WebSocketException(code=1008)
     return session

--- a/apps/api/jukebotx_api/settings.py
+++ b/apps/api/jukebotx_api/settings.py
@@ -11,8 +11,13 @@ class ApiSettings:
     discord_client_secret: str
     discord_redirect_uri: str
     discord_required_guild_id: str
+    discord_activity_client_id: str
+    discord_activity_client_secret: str
+    discord_activity_redirect_uri: str
     session_secret: str
     session_ttl_seconds: int
+    jwt_secret: str
+    jwt_ttl_seconds: int
     opus_cache_dir: str
     opus_cache_ttl_seconds: int
     opus_storage_provider: str
@@ -34,8 +39,13 @@ def load_api_settings() -> ApiSettings:
         discord_client_secret=os.environ.get("DISCORD_OAUTH_CLIENT_SECRET", ""),
         discord_redirect_uri=os.environ.get("DISCORD_OAUTH_REDIRECT_URI", ""),
         discord_required_guild_id=os.environ.get("DISCORD_GUILD_ID", ""),
+        discord_activity_client_id=os.environ.get("DISCORD_ACTIVITY_CLIENT_ID", ""),
+        discord_activity_client_secret=os.environ.get("DISCORD_ACTIVITY_CLIENT_SECRET", ""),
+        discord_activity_redirect_uri=os.environ.get("DISCORD_ACTIVITY_REDIRECT_URI", ""),
         session_secret=os.environ.get("API_SESSION_SECRET", ""),
         session_ttl_seconds=int(os.environ.get("API_SESSION_TTL_SECONDS", "86400")),
+        jwt_secret=os.environ.get("API_JWT_SECRET", ""),
+        jwt_ttl_seconds=int(os.environ.get("API_JWT_TTL_SECONDS", "900")),
         opus_cache_dir=os.environ.get("OPUS_CACHE_DIR", "static/opus"),
         opus_cache_ttl_seconds=int(os.environ.get("OPUS_CACHE_TTL_SECONDS", "604800")),
         opus_storage_provider=os.environ.get("OPUS_STORAGE_PROVIDER", "s3"),


### PR DESCRIPTION
### Motivation

- Provide a server-side endpoint to accept Discord Activity auth proofs and mint short-lived API JWTs for clients.
- Allow API and websocket clients to authenticate using a bearer JWT instead of only the session cookie.
- Centralize JWT creation/validation and support the Discord Activity OAuth flow alongside existing OAuth login.

### Description

- Added `POST /v1/auth/discord/exchange` in `apps/api/jukebotx_api/main.py` which accepts a proof, validates it with Discord, fetches the user and guilds, and returns a short-lived JWT payload (`DiscordActivityExchangeResponse`).
- Implemented JWT helpers in `apps/api/jukebotx_api/auth.py` including `_encode_jwt`, `_decode_jwt`, `create_api_jwt`, `parse_api_jwt`, `exchange_activity_proof`, and helper token extractors, plus auth dependencies `require_api_jwt`, `require_api_auth`, and `require_api_jwt_websocket` for HTTP and websocket use.
- Updated API routes to use `require_api_auth` so handlers accept either a valid session cookie or a bearer JWT (from `Authorization: Bearer <token>` or `access_token` query param), and added explicit websocket JWT extraction for socket auth.
- Extended `ApiSettings` in `apps/api/jukebotx_api/settings.py` with `discord_activity_client_id`, `discord_activity_client_secret`, `discord_activity_redirect_uri`, `jwt_secret`, and `jwt_ttl_seconds` to configure JWT and Activity flow credentials.

### Testing

- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cbf56becc832f888603ef64e019a1)