### PR TITLE
Add session state endpoints, JWT websocket events, and in-process broadcaster

### DIFF
--- a/apps/api/jukebotx_api/broadcaster.py
+++ b/apps/api/jukebotx_api/broadcaster.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+from uuid import UUID
+
+from jukebotx_core.contracts import EventEnvelope
+
+
+class SessionEventBroadcaster:
+    def __init__(self, *, max_queue_size: int = 100) -> None:
+        self._max_queue_size = max_queue_size
+        self._subscriptions: dict[UUID, set[asyncio.Queue[EventEnvelope]]] = {}
+        self._lock = asyncio.Lock()
+
+    @asynccontextmanager
+    async def subscribe(self, session_id: UUID) -> AsyncIterator[asyncio.Queue[EventEnvelope]]:
+        queue: asyncio.Queue[EventEnvelope] = asyncio.Queue(maxsize=self._max_queue_size)
+        async with self._lock:
+            self._subscriptions.setdefault(session_id, set()).add(queue)
+        try:
+            yield queue
+        finally:
+            async with self._lock:
+                queues = self._subscriptions.get(session_id)
+                if queues:
+                    queues.discard(queue)
+                    if not queues:
+                        self._subscriptions.pop(session_id, None)
+
+    async def publish(self, session_id: UUID, envelope: EventEnvelope) -> None:
+        async with self._lock:
+            queues = list(self._subscriptions.get(session_id, set()))
+        for queue in queues:
+            if queue.full():
+                try:
+                    queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
+            try:
+                queue.put_nowait(envelope)
+            except asyncio.QueueFull:
+                continue
+
+
+event_broadcaster = SessionEventBroadcaster()
+
+
+def get_event_broadcaster() -> SessionEventBroadcaster:
+    return event_broadcaster


### PR DESCRIPTION
### Motivation

- Provide API clients a simple way to read session state and subscribe to live session events via a websocket.
- Support fan-out of session event updates within an API instance with a pluggable broadcaster that can be swapped for Redis pub/sub later.
- Centralize session state assembly so HTTP endpoints and websocket consumers produce consistent payloads.

### Description

- Add an in-process event broadcaster `SessionEventBroadcaster` in `apps/api/jukebotx_api/broadcaster.py` with `subscribe`/`publish` primitives and a module-level `event_broadcaster` accessor as `get_event_broadcaster`.
- Add two REST endpoints: `GET /v1/sessions/active` and `GET /v1/sessions/{session_id}/state` that return `SessionStateDTO` and reuse a new `build_session_state` helper for composing state.
- Add a JWT-authenticated websocket route `GET /v1/sessions/{session_id}/events` that requires `require_api_jwt_websocket`, sends an initial `session.state` envelope, and streams `EventEnvelope` updates from the broadcaster to connected clients.
- Refactor `main.py` to import `JamSession`, wire the broadcaster via `Depends(get_event_broadcaster)`, and reuse `build_session_state` across endpoints and websocket logic.

### Testing

- No automated tests were executed for this change.
- Basic safety checks include verifying imports and type usages via static inspection during development.
- Websocket authentication reuses the existing `require_api_jwt_websocket` flow that was already exercised by other handlers.
- The in-process broadcaster has a bounded queue and eviction behavior to avoid unbounded memory growth when clients are slow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cc90e8410832fa367cc0e67217bca)