### PR TITLE
Add internal playback update events

### DIFF
--- a/apps/api/jukebotx_api/settings.py
+++ b/apps/api/jukebotx_api/settings.py
@@ -18,6 +18,7 @@ class ApiSettings:
     session_ttl_seconds: int
     jwt_secret: str
     jwt_ttl_seconds: int
+    internal_api_token: str
     opus_cache_dir: str
     opus_cache_ttl_seconds: int
     opus_storage_provider: str
@@ -46,6 +47,7 @@ def load_api_settings() -> ApiSettings:
         session_ttl_seconds=int(os.environ.get("API_SESSION_TTL_SECONDS", "86400")),
         jwt_secret=os.environ.get("API_JWT_SECRET", ""),
         jwt_ttl_seconds=int(os.environ.get("API_JWT_TTL_SECONDS", "900")),
+        internal_api_token=os.environ.get("INTERNAL_API_TOKEN", ""),
         opus_cache_dir=os.environ.get("OPUS_CACHE_DIR", "static/opus"),
         opus_cache_ttl_seconds=int(os.environ.get("OPUS_CACHE_TTL_SECONDS", "604800")),
         opus_storage_provider=os.environ.get("OPUS_STORAGE_PROVIDER", "s3"),

--- a/apps/bot/jukebotx_bot/internal_api.py
+++ b/apps/bot/jukebotx_bot/internal_api.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any
+import logging
+
+import httpx
+
+from jukebotx_bot.discord.session import Track
+
+logger = logging.getLogger(__name__)
+
+
+def serialize_track(track: Track) -> dict[str, Any]:
+    return {
+        "title": track.title,
+        "artist_display": track.artist_display,
+        "requester_id": track.requester_id,
+        "requester_name": track.requester_name,
+        "media_url": track.media_url,
+        "page_url": track.page_url,
+        "duration_seconds": track.duration_seconds,
+    }
+
+
+def build_queue_payload(queue: list[Track], now_playing: Track | None) -> dict[str, Any]:
+    preview = [serialize_track(item) for item in queue[:5]]
+    payload: dict[str, Any] = {
+        "queue_size": len(queue),
+        "queue_preview": preview,
+    }
+    if now_playing is not None:
+        payload["now_playing"] = serialize_track(now_playing)
+    return payload
+
+
+class InternalApiClient:
+    def __init__(self, base_url: str | None, token: str | None) -> None:
+        self._base_url = base_url
+        self._token = token
+
+    def _is_configured(self) -> bool:
+        return bool(self._base_url and self._token)
+
+    async def post_playback_update(
+        self,
+        *,
+        guild_id: int,
+        channel_id: int | None,
+        event_type: str,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        if not self._is_configured():
+            logger.debug("Internal API client not configured; skipping %s update.", event_type)
+            return
+        url = f"{self._base_url.rstrip('/')}/v1/internal/playback-updates"
+        payload = {
+            "guild_id": guild_id,
+            "channel_id": channel_id,
+            "event_type": event_type,
+            "data": data or {},
+        }
+        headers = {"Authorization": f"Bearer {self._token}"}
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.post(url, json=payload, headers=headers)
+            if resp.status_code >= 400:
+                logger.warning(
+                    "Internal API update failed (%s): %s",
+                    resp.status_code,
+                    resp.text,
+                )
+        except Exception as exc:
+            logger.warning("Internal API update failed: %s", exc)

--- a/apps/bot/jukebotx_bot/settings.py
+++ b/apps/bot/jukebotx_bot/settings.py
@@ -28,6 +28,8 @@ class BotSettings(BaseSettings):
     jam_session_role_id: int | None = Field(default=None, alias="JAM_SESSION_ROLE_ID")
     web_base_url: str | None = Field(default=None, alias="WEB_BASE_URL")
     opus_api_base_url: str | None = Field(default=None, alias="OPUS_API_BASE_URL")
+    internal_api_base_url: str | None = Field(default=None, alias="INTERNAL_API_BASE_URL")
+    internal_api_token: str | None = Field(default=None, alias="INTERNAL_API_TOKEN")
 
     # Pydantic v2 configuration
     model_config = SettingsConfigDict(


### PR DESCRIPTION
### Motivation
- Provide a simple internal channel for the bot to inform the API about playback and queue state changes so the API can broadcast websocket events to clients.
- Secure internal updates with a shared secret token instead of user-facing auth flows.
- Emit real-time updates from playback lifecycle points (`now playing`, `ended`) and queue mutation paths so web UIs and subscribers receive fresh state.

### Description
- Add a new internal endpoint `POST /v1/internal/playback-updates` that accepts `PlaybackUpdateRequest` and publishes an `EventEnvelope` via the existing `SessionEventBroadcaster`, protected by `require_internal_auth` and an `INTERNAL_API_TOKEN` setting.
- Introduce `apps/bot/jukebotx_bot/internal_api.py` with `InternalApiClient`, `serialize_track`, and `build_queue_payload`, and wire `INTERNAL_API_BASE_URL`/`INTERNAL_API_TOKEN` into bot settings and API settings (`INTERNAL_API_TOKEN`).
- Wire the internal client into the bot and audio stack: `AudioControllerManager`/`GuildAudioController` post `playback.now_playing` and `playback.ended` updates, and `JukeBot` calls `_notify_queue_update` after queue mutations (`add`, `playlist`, `clear`, `remove`, `leave`).
- Use the same broadcaster flow so the API emits websocket events to subscribed clients when internal updates arrive.

### Testing
- No automated tests were run as part of this change.
- Static code inspection (project search/review) was used to locate lifecycle points and wire update calls successfully.
- Basic runtime logging is present for failed internal API requests to aid debugging in environments where the internal API is not configured.
- Manual validation is recommended when deploying with `INTERNAL_API_TOKEN` and `INTERNAL_API_BASE_URL` configured to ensure events reach connected websocket clients.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cce133528832fab57645c61748580)