### PR TITLE
Add Activity (Astro) service and Makefile targets; optional Redis profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: bot api up up-d build down destroy logs ps restart \
+.PHONY: bot api dev up up-d build down destroy logs ps restart \
+        activity-install activity-dev activity-build activity-shell \
         db-shell db-reset db-backup db-restore fmt lint test smoke-suno smoke-playlist smoke-audio
 
 .ONESHELL:
@@ -6,6 +7,7 @@ SHELL := /bin/bash
 
 PYTHONPATH := apps/bot:apps/api:packages/core:packages/infra
 DC := docker compose
+CORE_SERVICES := db api worker bot activity minio
 
 # ---- Load .env into Make ----
 # This exports variables so recipes can use $(POSTGRES_USER), etc.
@@ -33,10 +35,13 @@ build:
 	$(DC) build
 
 up:
-	$(DC) up --build
+	$(DC) up --build $(CORE_SERVICES)
 
 up-d:
-	$(DC) up -d --build
+	$(DC) up -d --build $(CORE_SERVICES)
+
+dev:
+	$(DC) up --build $(CORE_SERVICES)
 
 down:
 	# Safe: preserves named volumes (your Postgres data)
@@ -54,6 +59,19 @@ ps:
 
 logs:
 	$(DC) logs -f
+
+# -------- Activity (Astro) --------
+activity-install:
+	cd apps/activity && npm install
+
+activity-dev:
+	cd apps/activity && npm run dev
+
+activity-build:
+	cd apps/activity && npm run build
+
+activity-shell:
+	cd apps/activity && /bin/bash
 
 # -------- Database helpers --------
 db-shell:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,16 @@ services:
     ports:
       - "8001:8000"
 
+  activity:
+    build:
+      context: .
+      dockerfile: apps/activity/Dockerfile
+    environment:
+      API_BASE_URL: http://api:8000
+    depends_on:
+      - api
+    ports:
+      - "4321:4321"
 
   worker:
     environment:
@@ -57,6 +67,13 @@ services:
     ports:
       - "9000:9000"
       - "9001:9001"
+
+  redis:
+    image: redis:7
+    profiles:
+      - pubsub
+    ports:
+      - "6379:6379"
 
 volumes:
   pgdata:


### PR DESCRIPTION
### Motivation

- Provide a local Astro-backed Activity frontend service that can reach the API over the Compose network for the Discord Activity/session UI.  
- Support optional Redis-backed pub/sub for websockets via a Compose profile.  
- Make Activity development and build workflows accessible from the repository `Makefile` for a consistent developer experience.  

### Description

- Added an `activity` service to `docker-compose.yml` that builds from `apps/activity/Dockerfile`, depends on `api`, exposes port `4321`, and sets `API_BASE_URL` to `http://api:8000`.  
- Added an optional `redis` service to `docker-compose.yml` under the `pubsub` profile to enable local pub/sub when required.  
- Introduced `CORE_SERVICES` in the `Makefile` and updated `up`, `up-d`, and added `dev` to bring up the core services including `activity`.  
- Added `activity-install`, `activity-dev`, `activity-build`, and `activity-shell` Make targets to run `npm` workflows inside `apps/activity`.  

### Testing

- No automated tests were run against these changes.  
- Standard `Makefile` commands remain available (e.g., `make up`, `make up-d`, `make dev`) and were exercised manually for wiring verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ce7bbcd7c832facff705228eb8a7e)