### PR TITLE
feat: add activity astro app

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This repo is set up so you can:
 
   * [Bot](#bot)
   * [API](#api)
+  * [Activity app](#activity-app)
   * [API endpoints](#api-endpoints)
 * [Commands](#commands)
 * [Smoke tests](#smoke-tests)
@@ -52,6 +53,10 @@ This repo is set up so you can:
 
   * FastAPI service intended to expose ingestion/config/queue endpoints later
   * Currently structured to follow the same domain-first boundaries
+
+* **Activity app** (`apps/activity`)
+
+  * Astro front end for a session activity/landing experience
 
 * **Core domain + use cases** (`packages/core`)
 
@@ -123,6 +128,12 @@ jukebotx-service-full/
 │     ├─ Dockerfile
 │     └─ jukebotx_api/
 │        └─ main.py
+│  └─ activity/
+│     ├─ astro.config.mjs
+│     ├─ package.json
+│     └─ src/
+│        └─ pages/
+│           └─ index.astro
 ├─ packages/
 │  ├─ core/
 │  │  └─ jukebotx_core/
@@ -241,6 +252,18 @@ Or manually:
 PYTHONPATH=apps/bot:apps/api:packages/core:packages/infra \
 poetry run uvicorn jukebotx_api.main:app --reload
 ```
+
+---
+
+## Activity app
+
+```bash
+cd apps/activity
+npm install
+npm run dev
+```
+
+The Activity app runs on <http://localhost:4321> by default.
 
 ---
 

--- a/apps/activity/README.md
+++ b/apps/activity/README.md
@@ -1,0 +1,13 @@
+# Activity app
+
+A minimal Astro front end for the JukeBotx activity view.
+
+## Run locally
+
+```bash
+cd apps/activity
+npm install
+npm run dev
+```
+
+Astro will start the dev server at <http://localhost:4321>.

--- a/apps/activity/astro.config.mjs
+++ b/apps/activity/astro.config.mjs
@@ -1,0 +1,5 @@
+import { defineConfig } from "astro/config";
+
+export default defineConfig({
+  output: "static",
+});

--- a/apps/activity/package.json
+++ b/apps/activity/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@jukebotx/activity",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "astro": "astro"
+  },
+  "dependencies": {
+    "astro": "^4.13.0"
+  }
+}

--- a/apps/activity/src/pages/index.astro
+++ b/apps/activity/src/pages/index.astro
@@ -1,0 +1,125 @@
+---
+const features = [
+  "Share session links with the community",
+  "Track the queue in real time",
+  "Highlight the currently playing track",
+  "Celebrate new submissions",
+];
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>JukeBotx Activity</title>
+  </head>
+  <body>
+    <main class="page">
+      <section class="hero">
+        <p class="eyebrow">JukeBotx</p>
+        <h1>Activity</h1>
+        <p class="lede">
+          A lightweight activity view for Discord jam sessions. Launch this app to keep
+          the crowd in sync.
+        </p>
+        <div class="actions">
+          <a class="primary" href="#get-started">Get started</a>
+          <a class="secondary" href="https://github.com" target="_blank" rel="noreferrer">
+            Learn more
+          </a>
+        </div>
+      </section>
+
+      <section id="get-started" class="card">
+        <h2>What it will do</h2>
+        <ul>
+          {features.map((feature) => (
+            <li>{feature}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section class="card">
+        <h2>Status</h2>
+        <p>
+          This Activity app is freshly bootstrapped with Astro. Add API calls and real-time
+          updates once the endpoints are ready.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>
+
+<style>
+  :global(body) {
+    margin: 0;
+    font-family: "Inter", system-ui, -apple-system, sans-serif;
+    background: #0b0f18;
+    color: #e6e9f4;
+  }
+
+  .page {
+    min-height: 100vh;
+    padding: 4rem 6vw;
+    display: grid;
+    gap: 2rem;
+  }
+
+  .hero {
+    display: grid;
+    gap: 1rem;
+    max-width: 640px;
+  }
+
+  .eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    font-size: 0.75rem;
+    color: #7aa2ff;
+    margin: 0;
+  }
+
+  .lede {
+    font-size: 1.1rem;
+    color: #b7bedc;
+  }
+
+  .actions {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .actions a {
+    padding: 0.75rem 1.5rem;
+    border-radius: 999px;
+    text-decoration: none;
+    font-weight: 600;
+  }
+
+  .actions .primary {
+    background: #7aa2ff;
+    color: #0b0f18;
+  }
+
+  .actions .secondary {
+    border: 1px solid #2a3350;
+    color: inherit;
+  }
+
+  .card {
+    background: #111827;
+    border: 1px solid #1f2a44;
+    border-radius: 1rem;
+    padding: 1.5rem;
+    max-width: 720px;
+  }
+
+  ul {
+    padding-left: 1.2rem;
+  }
+
+  li {
+    margin-bottom: 0.5rem;
+  }
+</style>


### PR DESCRIPTION
### Motivation

* Provide a minimal front-end Activity app to display session activity and a landing page for the project. 
* Bootstrap an Astro-based app that can be developed independently inside the monorepo. 
* Align repo docs and layout so the new app is discoverable and has local run instructions. 

### Description

* Added a new Astro app under `apps/activity` including `package.json`, `astro.config.mjs`, and a basic landing page at `apps/activity/src/pages/index.astro` to boot the app. 
* Added `apps/activity/README.md` with local run instructions (`npm install` / `npm run dev`). 
* Updated the root `README.md` to mention the Activity app in the repo layout and to document how to run it locally. 
* Committed the new files so the app is present in the monorepo tree. 

### Testing

* Ran `npm install` in `apps/activity` to verify dependency resolution, which failed with a `403 Forbidden` fetching `astro` from the npm registry. 
* No other automated tests were executed as part of this change (Python/Poetry targets were not modified).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695df445ea98832f8c974fb146589df0)