### PR TITLE
Use public API base URL for Activity builds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,7 @@ OPUS_API_BASE_URL=http://api:8000
 # Cloudflare Tunnel
 CLOUDFLARED_TOKEN=your-cloudflared-token
 CLOUDFLARED_API_TOKEN=your-cloudflared-api-token
+PUBLIC_API_BASE_URL=https://your-api-tunnel.example.com
 
 # API
 API_HOST=0.0.0.0

--- a/README.md
+++ b/README.md
@@ -265,6 +265,11 @@ npm run dev
 
 The Activity app runs on <http://localhost:4321> by default.
 
+When running the Activity inside Discord, set `PUBLIC_API_BASE_URL` in the root `.env`
+to a publicly reachable API origin (for example the Cloudflared API URL) and rebuild
+the Activity container so the client bundle picks up the new base URL
+(`docker compose build activity`).
+
 ---
 
 ## API endpoints

--- a/apps/activity/.env.example
+++ b/apps/activity/.env.example
@@ -1,2 +1,2 @@
 PUBLIC_ACTIVITY_CLIENT_ID=zzzzzzzzzzzzzzzz
-PUBLIC_API_BASE_URL=http://localhost:8001
+PUBLIC_API_BASE_URL=https://your-api-tunnel.example.com

--- a/apps/activity/README.md
+++ b/apps/activity/README.md
@@ -15,4 +15,5 @@ Astro will start the dev server at <http://localhost:4321>.
 ## Environment variables
 
 - `PUBLIC_ACTIVITY_CLIENT_ID` lives in `apps/activity/.env` and is exposed to the browser.
+- `PUBLIC_API_BASE_URL` must be a publicly reachable API origin when running the Activity in Discord (for example a Cloudflared URL).
 - Secrets like `DISCORD_CLIENT_SECRET` should stay in the root `.env` and never use the `PUBLIC_` prefix.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       context: .
       dockerfile: apps/activity/Dockerfile
     environment:
-      PUBLIC_API_BASE_URL: http://localhost:8001
+      PUBLIC_API_BASE_URL: ${PUBLIC_API_BASE_URL}
     depends_on:
       - api
     ports:


### PR DESCRIPTION
### Motivation

- The Activity front-end currently hard-codes `http://localhost:8001` as the API origin which is not reachable from Discord/externally.
- The change makes the Activity client use a publicly reachable API origin (for example a Cloudflared tunnel) so Activity sessions work when embedded in Discord.

### Description

- Read `PUBLIC_API_BASE_URL` from the environment in `docker-compose.yml` for the `activity` service (`PUBLIC_API_BASE_URL: ${PUBLIC_API_BASE_URL}`).
- Add a sample `PUBLIC_API_BASE_URL` entry to the root `.env.example` and update `apps/activity/.env.example` to show a public tunnel URL.
- Document that `PUBLIC_API_BASE_URL` must be a public API origin and that the Activity container should be rebuilt so the client bundle picks up the new base URL in `README.md` and `apps/activity/README.md`.

### Testing

- No automated tests were run because this change modifies configuration and documentation only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e34d32f6c832fafc9a7cf121b4715)