### PR TITLE
Align Activity client ID with API and add fail-fast validation for activity OAuth

### DIFF
--- a/apps/activity/.env.example
+++ b/apps/activity/.env.example
@@ -1,2 +1,2 @@
-PUBLIC_ACTIVITY_CLIENT_ID=zzzzzzzzzzzzzzzz
+PUBLIC_ACTIVITY_CLIENT_ID=your-discord-activity-client-id
 PUBLIC_API_BASE_URL=https://your-api-tunnel.example.com

--- a/apps/activity/README.md
+++ b/apps/activity/README.md
@@ -15,6 +15,7 @@ Astro will start the dev server at <http://localhost:4321>.
 ## Environment variables
 
 - `PUBLIC_ACTIVITY_CLIENT_ID` lives in `apps/activity/.env` and is exposed to the browser.
+  It must match the API's `DISCORD_ACTIVITY_CLIENT_ID` so both use the same Discord Activity app.
 - `PUBLIC_API_BASE_URL` must be a publicly reachable API origin when running the Activity in Discord (for example a Cloudflared URL).
 - When running inside Discord, ensure the API CORS settings include the Activity origin (`CORS_ALLOWED_ORIGINS`)
   and Discord embed origins (for example `https://discord.com` and `https://.*\.discordsays\.com`).

--- a/apps/api/jukebotx_api/auth.py
+++ b/apps/api/jukebotx_api/auth.py
@@ -231,8 +231,8 @@ def ensure_jwt_configured(settings: ApiSettings) -> None:
 
 
 def ensure_activity_oauth_configured(settings: ApiSettings) -> tuple[str, str, str | None]:
-    client_id = settings.discord_activity_client_id or settings.discord_client_id
-    client_secret = settings.discord_activity_client_secret or settings.discord_client_secret
+    client_id = settings.discord_activity_client_id
+    client_secret = settings.discord_activity_client_secret
     redirect_uri = settings.discord_activity_redirect_uri or settings.discord_redirect_uri
     missing = [
         name
@@ -245,7 +245,15 @@ def ensure_activity_oauth_configured(settings: ApiSettings) -> tuple[str, str, s
     ]
     if missing:
         missing_list = ", ".join(missing)
-        raise HTTPException(status_code=500, detail=f"Activity configuration incomplete: {missing_list}")
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                "Activity configuration incomplete: "
+                f"{missing_list}. Set DISCORD_ACTIVITY_CLIENT_ID and "
+                "DISCORD_ACTIVITY_CLIENT_SECRET to the same Discord Activity app "
+                "used by PUBLIC_ACTIVITY_CLIENT_ID."
+            ),
+        )
     return client_id, client_secret, redirect_uri or None
 
 


### PR DESCRIPTION
### Motivation
- Ensure the Activity front-end uses the same Discord Activity application as the API to avoid mismatched OAuth flows.
- Make the API fail fast and provide a clear error when Activity OAuth credentials are missing or misconfigured.

### Description
- Update `apps/activity/.env.example` to use a clearer placeholder `your-discord-activity-client-id` for `PUBLIC_ACTIVITY_CLIENT_ID`.
- Clarify in `apps/activity/README.md` that `PUBLIC_ACTIVITY_CLIENT_ID` must match the API's `DISCORD_ACTIVITY_CLIENT_ID`.
- Change `ensure_activity_oauth_configured` in `apps/api/jukebotx_api/auth.py` to require `discord_activity_client_id`/`discord_activity_client_secret` explicitly (remove fallback to general OAuth client) and raise a clearer `HTTPException` instructing to align `DISCORD_ACTIVITY_CLIENT_ID`/`DISCORD_ACTIVITY_CLIENT_SECRET` with `PUBLIC_ACTIVITY_CLIENT_ID`.
- Preserve existing `redirect_uri` resolution behavior while tightening activity-specific credential checks.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e7a4dadf8832f9c4988f1687fe12a)