### PR TITLE
docs: expand Makefile usage notes and document compose/env layering

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -1,0 +1,22 @@
+# Environment
+ENV=development
+LOG_LEVEL=INFO
+
+# Database
+POSTGRES_HOST=db
+POSTGRES_PORT=5432
+POSTGRES_DB=jukebotx
+POSTGRES_USER=jukebotx
+POSTGRES_PASSWORD=jukebotx
+DATABASE_URL=postgresql+asyncpg://jukebotx:jukebotx@db:5432/jukebotx
+
+# Local URLs
+WEB_BASE_URL=http://localhost:8001
+OPUS_API_BASE_URL=http://api:8000
+PUBLIC_API_BASE_URL=http://localhost:8001
+
+# API
+API_HOST=0.0.0.0
+API_PORT=8000
+API_SESSION_SECRET=change-me
+CORS_ALLOWED_ORIGINS=http://localhost:4321,https://discord.com

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,22 @@
+# Environment
+ENV=production
+LOG_LEVEL=INFO
+
+# Database
+POSTGRES_HOST=your-db-host
+POSTGRES_PORT=5432
+POSTGRES_DB=jukebotx
+POSTGRES_USER=jukebotx
+POSTGRES_PASSWORD=change-me
+DATABASE_URL=postgresql+asyncpg://jukebotx:change-me@your-db-host:5432/jukebotx
+
+# Public URLs
+WEB_BASE_URL=https://your-domain.example.com
+OPUS_API_BASE_URL=https://your-api.example.com
+PUBLIC_API_BASE_URL=https://your-api.example.com
+
+# API
+API_HOST=0.0.0.0
+API_PORT=8000
+API_SESSION_SECRET=change-me
+CORS_ALLOWED_ORIGINS=https://your-domain.example.com,https://discord.com

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 .env
 .env.*
 !.env.example
+!.env.development.example
+!.env.production.example
 *.pem
 *.key
 secrets/

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,22 @@
+services:
+  api:
+    env_file:
+      - .env.development
+
+  worker:
+    env_file:
+      - .env.development
+    profiles:
+      - worker
+
+  bot:
+    env_file:
+      - .env.development
+    profiles:
+      - bot
+
+  activity:
+    env_file:
+      - .env.development
+    profiles:
+      - activity

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,16 @@
+services:
+  api:
+    env_file:
+      - .env.production
+
+  worker:
+    env_file:
+      - .env.production
+
+  bot:
+    env_file:
+      - .env.production
+
+  activity:
+    env_file:
+      - .env.production

--- a/docker-compose.tunnel.yml
+++ b/docker-compose.tunnel.yml
@@ -1,0 +1,13 @@
+services:
+  cloudflared:
+    image: cloudflare/cloudflared:2024.6.1
+    command: tunnel --no-autoupdate run --token ${CLOUDFLARED_TOKEN}
+    depends_on:
+      - api
+      - activity
+
+  cloudflared-api:
+    image: cloudflare/cloudflared:2024.6.1
+    command: tunnel --no-autoupdate run --token ${CLOUDFLARED_API_TOKEN}
+    depends_on:
+      - api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,19 +75,6 @@ services:
     ports:
       - "6379:6379"
 
-  cloudflared:
-    image: cloudflare/cloudflared:2024.6.1
-    command: tunnel --no-autoupdate run --token ${CLOUDFLARED_TOKEN}
-    depends_on:
-      - api
-      - activity
-
-  cloudflared-api:
-    image: cloudflare/cloudflared:2024.6.1
-    command: tunnel --no-autoupdate run --token ${CLOUDFLARED_API_TOKEN}
-    depends_on:
-      - api
-
 volumes:
   pgdata:
   minio_data:


### PR DESCRIPTION
### Motivation
- Clarify compose layering and env-file selection so different stacks (dev/prod/tunnel) are explicit and easy to run.
- Provide quick `make` guidance and a `help` target to reduce friction for common workflows.
- Make the Cloudflare tunnel opt-in by moving tunnel services into a separate compose layer.
- Provide committed example env files so contributors can copy and customize local/production settings.

### Description
- Update the `Makefile` with usage comments, add a `help` target, and introduce `ENV_FILE`, `DC_ENV_OPT`, and layered `COMPOSE_FILES` variables so all `docker compose` invocations use `$(COMPOSE_FILES)` and `$(DC_ENV_OPT)`.
- Add convenience targets `up-dev`, `up-dev-d`, `up-prod`, and `up-prod-d` that invoke `up` with the appropriate `COMPOSE_FILES` and `ENV_FILE` (e.g., `make up-dev`).
- Add `docker-compose.dev.yml`, `docker-compose.prod.yml`, and `docker-compose.tunnel.yml`, and remove the `cloudflared` services from the base `docker-compose.yml` to make the tunnel opt-in.
- Add `.env.development.example` and `.env.production.example` and update `.gitignore` to allow committing those example env files.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f42ea7034832f922f35624b1c6026)