### PR TITLE
Adjust help command for mod visibility and orange mod embed

### DIFF
--- a/apps/bot/jukebotx_bot/main.py
+++ b/apps/bot/jukebotx_bot/main.py
@@ -308,6 +308,7 @@ class JukeBot(commands.Bot):
     def _register_commands(self) -> None:
         @self.command(name="help")
         async def help_command(ctx: commands.Context) -> None:
+            is_mod = isinstance(ctx.author, discord.Member) and _is_mod(ctx.author)
             embed = discord.Embed(
                 title="JukeBotx Help",
                 description=(
@@ -315,13 +316,13 @@ class JukeBot(commands.Bot):
                     "Drop Suno links in chat to queue when submissions are open. "
                     "Use `;playlist <url>` for Suno playlists (mods only)."
                 ),
-                color=discord.Color.blurple(),
+                color=discord.Color.orange() if is_mod else discord.Color.blurple(),
             )
             embed.add_field(
                 name="Session",
                 value=(
-                    "`;join` — Join your voice channel.\n"
-                    "`;leave` — Leave and reset the session.\n"
+                    "`;join` — Join your voice channel (mods).\n"
+                    "`;leave` — Leave and reset the session (mods).\n"
                     "`;open` / `;close` — Toggle submissions (mods).\n"
                     "`;web` — Share the session web URL.\n"
                     "`;setlist` — DM the current session setlist."
@@ -339,32 +340,33 @@ class JukeBot(commands.Bot):
                 ),
                 inline=False,
             )
-            embed.add_field(
-                name="Queue Management (mods)",
-                value=(
-                    "`;playlist <url>` — Queue a Suno playlist and close submissions.\n"
-                    "`;clear` — Clear the queue.\n"
-                    "`;remove <index>` — Remove a queued item.\n"
-                    "`;limit <count>` — Set per-user submission limit."
-                ),
-                inline=False,
-            )
-            embed.add_field(
-                name="Autoplay + DJ Mode (mods)",
-                value=(
-                    "`;autoplay` — Enable autoplay until the queue ends.\n"
-                    "`;autoplay <count>` — Play the next N tracks.\n"
-                    "`;autoplay off` — Disable autoplay.\n"
-                    "`;cooldown` / `;cooldown <minutes>` / `;cooldown off` — Toggle submission cooldown.\n"
-                    "`;dj` / `;dj <count>` / `;dj off` — Toggle DJ mode."
-                ),
-                inline=False,
-            )
-            embed.add_field(
-                name="Announcements (mods)",
-                value="`;ping here <message>` or `;ping jamsession <message>` — Ping channels/roles.",
-                inline=False,
-            )
+            if is_mod:
+                embed.add_field(
+                    name="Queue Management (mods)",
+                    value=(
+                        "`;playlist <url>` — Queue a Suno playlist and close submissions.\n"
+                        "`;clear` — Clear the queue.\n"
+                        "`;remove <index>` — Remove a queued item.\n"
+                        "`;limit <count>` — Set per-user submission limit."
+                    ),
+                    inline=False,
+                )
+                embed.add_field(
+                    name="Autoplay + DJ Mode (mods)",
+                    value=(
+                        "`;autoplay` — Enable autoplay until the queue ends.\n"
+                        "`;autoplay <count>` — Play the next N tracks.\n"
+                        "`;autoplay off` — Disable autoplay.\n"
+                        "`;cooldown` / `;cooldown <minutes>` / `;cooldown off` — Toggle submission cooldown.\n"
+                        "`;dj` / `;dj <count>` / `;dj off` — Toggle DJ mode."
+                    ),
+                    inline=False,
+                )
+                embed.add_field(
+                    name="Announcements (mods)",
+                    value="`;ping here <message>` or `;ping jamsession <message>` — Ping channels/roles.",
+                    inline=False,
+                )
             embed.set_footer(text="Need help? Ask a mod or use ;help anytime.")
             await ctx.send(embed=embed)
 


### PR DESCRIPTION
### Motivation
- Make the `;help` output present a version tailored to moderators so mod-only commands are clearly labeled and not shown to regular users.
- Ensure wording in the "Session" field consistently marks mod-only commands like other help sections.
- Use an orange color scheme for the mod-specific help embed to visually distinguish it from the default blue.

### Description
- Add an `is_mod` check in the `help_command` to detect whether `ctx.author` is a moderator via existing `_is_mod` logic.
- Use `discord.Color.orange()` for the embed when `is_mod` is true and keep `discord.Color.blurple()` for non-mods.
- Update the "Session" field to append `(mods)` to `;join` and `;leave` and keep other mod mentions consistent.
- Conditionally include the mod-only sections (`Queue Management`, `Autoplay + DJ Mode`, and `Announcements`) only when `is_mod` is true.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968a27588a8832f844a4f055e2ccd5a)