### PR TITLE
Add composite Suno client with deterministic fallback merge

### DIFF
--- a/apps/bot/jukebotx_bot/main.py
+++ b/apps/bot/jukebotx_bot/main.py
@@ -23,12 +23,16 @@ from jukebotx_bot.discord.now_playing import build_now_playing_embed
 from jukebotx_bot.discord.session import CooldownMode, SessionManager, Track
 from jukebotx_bot.discord.suno import extract_suno_urls
 from jukebotx_bot.settings import load_bot_settings
-from jukebotx_core.use_cases.ingest_suno_links import IngestSunoLink, IngestSunoLinkInput
+from jukebotx_core.use_cases.ingest_suno_links import (
+    IngestSunoLink,
+    IngestSunoLinkInput,
+)
 from jukebotx_infra.db import async_session_factory, init_db
 from jukebotx_infra.repos.queue_repo import PostgresQueueRepository
 from jukebotx_infra.repos.submission_repo import PostgresSubmissionRepository
 from jukebotx_infra.repos.track_repo import PostgresTrackRepository
-from jukebotx_infra.suno.client import HttpxSunoClient, SunoScrapeError
+from jukebotx_infra.suno.client import SunoScrapeError
+from jukebotx_infra.suno.fallback_client import FallbackSunoClient
 from jukebotx_infra.suno.playlist_client import HttpxSunoPlaylistClient
 
 
@@ -48,6 +52,7 @@ class BotDeps:
     Dependencies for the bot.
     Keeping these in one object makes lifecycle + testing much saner.
     """
+
     session_manager: SessionManager
     ingest_use_case: IngestSunoLink
     audio_manager: AudioControllerManager
@@ -128,14 +133,18 @@ class JukeBot(commands.Bot):
         )
 
     def _record_track_addition(self, session, requester_id: int) -> None:
-        session.per_user_counts[requester_id] = session.per_user_counts.get(requester_id, 0) + 1
+        session.per_user_counts[requester_id] = (
+            session.per_user_counts.get(requester_id, 0) + 1
+        )
         session.total_tracks_added += 1
 
     # -----------------------------
     # Events
     # -----------------------------
     def _register_events(self) -> None:
-        async def _send_submission_feedback(message: discord.Message, content: str) -> None:
+        async def _send_submission_feedback(
+            message: discord.Message, content: str
+        ) -> None:
             try:
                 await message.author.send(content)
                 return
@@ -150,7 +159,9 @@ class JukeBot(commands.Bot):
                 return
 
         @self.event
-        async def on_command_error(ctx: commands.Context, error: commands.CommandError) -> None:
+        async def on_command_error(
+            ctx: commands.Context, error: commands.CommandError
+        ) -> None:
             if isinstance(error, commands.CheckFailure):
                 await ctx.send("🚫 You don’t have permission to use that command.")
                 return
@@ -167,23 +178,21 @@ class JukeBot(commands.Bot):
             """
             Fired when the client has connected and the bot identity is known.
             """
-            assert self.user is not None, "client.user is unexpectedly None in on_ready()"
+            assert (
+                self.user is not None
+            ), "client.user is unexpectedly None in on_ready()"
 
             bot_name = self.user.name.lower().strip()
             env = self.settings.env.lower().strip()
 
             # Production safety: prevent using a dev bot identity with production settings.
-            assert (
-                env != "production" or "dev" not in bot_name
-            ), (
+            assert env != "production" or "dev" not in bot_name, (
                 "Safety check failed: ENV=production but the connected Discord bot name "
                 "contains 'dev'. You are likely using the DEV bot token in production."
             )
 
             # Development safety: prevent using prod bot identity in development.
-            assert (
-                env != "development" or "dev" in bot_name
-            ), (
+            assert env != "development" or "dev" in bot_name, (
                 "Safety check failed: ENV=development but the connected Discord bot name "
                 "does NOT contain 'dev'. You are likely using the production bot token in development."
             )
@@ -230,7 +239,9 @@ class JukeBot(commands.Bot):
             failure_count = 0
 
             session = self.deps.session_manager.for_guild(message.guild.id)
-            is_host = isinstance(message.author, discord.Member) and _is_mod(message.author)
+            is_host = isinstance(message.author, discord.Member) and _is_mod(
+                message.author
+            )
             user_id = message.author.id
             remaining_slots: int | None = None
 
@@ -245,13 +256,13 @@ class JukeBot(commands.Bot):
                             blocked_reason = "You have reached the submission limit for this session."
                     if blocked_reason is None and self._session_limit_reached(session):
                         session.submissions_open = False
-                        blocked_reason = "Session closed at limit: no more tracks can be added."
+                        blocked_reason = (
+                            "Session closed at limit: no more tracks can be added."
+                        )
                     if blocked_reason is None:
                         if session.cooldown_mode == CooldownMode.QUEUE:
                             if session.has_user_track_in_queue(user_id):
-                                blocked_reason = (
-                                    "Queue cooldown is enabled. You already have a track in queue or now playing."
-                                )
+                                blocked_reason = "Queue cooldown is enabled. You already have a track in queue or now playing."
                         else:
                             cooldown_remaining = session.cooldown_remaining(user_id)
                             if cooldown_remaining > 0:
@@ -334,7 +345,6 @@ class JukeBot(commands.Bot):
                 if remaining_slots is not None:
                     remaining_slots -= 1
 
-
             if added_any:
                 session.mark_submission(user_id)
                 try:
@@ -344,7 +354,9 @@ class JukeBot(commands.Bot):
 
             if success_count > 0 and failure_count > 0:
                 try:
-                    await message.channel.send(f"Queued {success_count} link(s); {failure_count} failed (see logs).")
+                    await message.channel.send(
+                        f"Queued {success_count} link(s); {failure_count} failed (see logs)."
+                    )
                 except discord.HTTPException:
                     pass
 
@@ -366,7 +378,9 @@ class JukeBot(commands.Bot):
                 )
 
             if skipped_playlist:
-                await message.channel.send("Playlist links aren’t auto-ingested. Use `;playlist <url>` instead.")
+                await message.channel.send(
+                    "Playlist links aren’t auto-ingested. Use `;playlist <url>` instead."
+                )
 
             await self.process_commands(message)
 
@@ -460,14 +474,15 @@ class JukeBot(commands.Bot):
             try:
                 await channel.connect()
             except discord.Forbidden:
-                await ctx.send("🚫 I don't have permission to join that voice channel (View/Connect).")
+                await ctx.send(
+                    "🚫 I don't have permission to join that voice channel (View/Connect)."
+                )
                 return
             except Exception as exc:
                 await ctx.send(f"⚠️ Failed to join VC: {type(exc).__name__}: {exc}")
                 raise
 
             await ctx.send(f"Joined {channel.name}!")
-
 
         @self.command(name="leave")
         async def leave(ctx: commands.Context) -> None:
@@ -518,11 +533,15 @@ class JukeBot(commands.Bot):
                 return
 
             channel_name = ctx.author.voice.channel.name.lower().strip()
-            channel_slug = re.sub(r"[^a-z0-9]+", "_", channel_name).strip("_") or "session"
+            channel_slug = (
+                re.sub(r"[^a-z0-9]+", "_", channel_name).strip("_") or "session"
+            )
             date_stamp = datetime.now(timezone.utc).strftime("%b_%d_%Y").lower()
             filename = f"{channel_slug}_{date_stamp}.csv"
 
-            with tempfile.NamedTemporaryFile("w", encoding="utf-8", newline="", delete=False) as tmp_file:
+            with tempfile.NamedTemporaryFile(
+                "w", encoding="utf-8", newline="", delete=False
+            ) as tmp_file:
                 writer = csv.writer(tmp_file)
                 writer.writerow(["Artist", "Title", "URL", "Requested By"])
                 for track in tracks:
@@ -532,7 +551,11 @@ class JukeBot(commands.Bot):
                     requester = ""
                     if track.requester_id is not None:
                         member = ctx.guild.get_member(track.requester_id)
-                        requester = member.display_name if member is not None else str(track.requester_id)
+                        requester = (
+                            member.display_name
+                            if member is not None
+                            else str(track.requester_id)
+                        )
                     writer.writerow([artist, title, url, requester])
                 tmp_path = tmp_file.name
 
@@ -548,7 +571,9 @@ class JukeBot(commands.Bot):
                     file=discord.File(tmp_path, filename=filename),
                 )
             except discord.Forbidden:
-                await ctx.send("I couldn't DM you the setlist. Please enable DMs and try again.")
+                await ctx.send(
+                    "I couldn't DM you the setlist. Please enable DMs and try again."
+                )
                 return
             finally:
                 try:
@@ -644,7 +669,9 @@ class JukeBot(commands.Bot):
 
             target_channel = ctx.channel
             if self.settings.jam_session_channel_id is not None:
-                configured_channel = ctx.guild.get_channel(self.settings.jam_session_channel_id)
+                configured_channel = ctx.guild.get_channel(
+                    self.settings.jam_session_channel_id
+                )
                 if isinstance(configured_channel, discord.abc.Messageable):
                     target_channel = configured_channel
 
@@ -672,7 +699,9 @@ class JukeBot(commands.Bot):
                 return
 
             if "https://suno.com/playlist/" not in url:
-                await ctx.send("Please provide a Suno playlist URL like https://suno.com/playlist/....")
+                await ctx.send(
+                    "Please provide a Suno playlist URL like https://suno.com/playlist/...."
+                )
                 return
 
             try:
@@ -689,7 +718,9 @@ class JukeBot(commands.Bot):
             if session.per_user_limit is not None and not _is_mod(ctx.author):
                 current = session.per_user_counts.get(user_id, 0)
                 if current + len(playlist_data.items) > session.per_user_limit:
-                    await ctx.send("You have reached the submission limit for this session.")
+                    await ctx.send(
+                        "You have reached the submission limit for this session."
+                    )
                     return
 
             if self._session_limit_reached(session):
@@ -721,7 +752,9 @@ class JukeBot(commands.Bot):
                             )
                         )
                     except SunoScrapeError as exc:
-                        logging.warning("Failed to ingest Suno URL %s: %s", ingest_url, exc)
+                        logging.warning(
+                            "Failed to ingest Suno URL %s: %s", ingest_url, exc
+                        )
                     else:
                         if ingest_result.track_title:
                             track_title = ingest_result.track_title
@@ -771,7 +804,11 @@ class JukeBot(commands.Bot):
                     f"{accepted_count} track(s) from the playlist. Submissions are now closed."
                 )
 
-            if session.autoplay_enabled and session.now_playing is None and ctx.voice_client is not None:
+            if (
+                session.autoplay_enabled
+                and session.now_playing is None
+                and ctx.voice_client is not None
+            ):
                 audio = self._get_audio(ctx).for_guild(ctx.guild.id, session)
                 started = await audio.play_next(ctx.voice_client)
                 if started is not None:
@@ -790,7 +827,9 @@ class JukeBot(commands.Bot):
             if session.submissions_open:
                 lines.append("Session is open.")
                 if isinstance(ctx.author, discord.Member) and _is_mod(ctx.author):
-                    lines.append("Add a Suno URL to queue a song, or use `;playlist <url>`.")
+                    lines.append(
+                        "Add a Suno URL to queue a song, or use `;playlist <url>`."
+                    )
                 else:
                     lines.append("Add a Suno URL to queue a song.")
             else:
@@ -846,7 +885,9 @@ class JukeBot(commands.Bot):
             session.now_playing_channel_id = ctx.channel.id
             audio = self._get_audio(ctx).for_guild(ctx.guild.id, session)
             if session.now_playing is not None:
-                await ctx.send(f"Already playing: {session.now_playing.title}. Use ;n to skip.")
+                await ctx.send(
+                    f"Already playing: {session.now_playing.title}. Use ;n to skip."
+                )
                 return
 
             if not session.queue:
@@ -988,7 +1029,9 @@ class JukeBot(commands.Bot):
                 return
 
             track = session.queue.pop(index - 1)
-            await ctx.send(f"Removed: {track.title} (requested by {track.requester_name}).")
+            await ctx.send(
+                f"Removed: {track.title} (requested by {track.requester_name})."
+            )
 
         @self.command(name="limit")
         async def limit(ctx: commands.Context, *args: str) -> None:
@@ -1100,7 +1143,9 @@ class JukeBot(commands.Bot):
 
             if lowered == "-queue":
                 session.cooldown_mode = CooldownMode.QUEUE
-                await ctx.send("Submission cooldown set to queue mode (one active track per user).")
+                await ctx.send(
+                    "Submission cooldown set to queue mode (one active track per user)."
+                )
                 return
 
             if lowered == "off":
@@ -1112,7 +1157,9 @@ class JukeBot(commands.Bot):
             try:
                 minutes = int(value)
             except ValueError:
-                await ctx.send("Cooldown value must be a number of minutes, '-queue', or 'off'.")
+                await ctx.send(
+                    "Cooldown value must be a number of minutes, '-queue', or 'off'."
+                )
                 return
 
             if minutes < 1:
@@ -1175,7 +1222,7 @@ def build_bot() -> JukeBot:
         session_manager=SessionManager(),
         audio_manager=AudioControllerManager(),
         ingest_use_case=IngestSunoLink(
-            suno_client=HttpxSunoClient(),
+            suno_client=FallbackSunoClient(),
             track_repo=PostgresTrackRepository(async_session_factory),
             submission_repo=PostgresSubmissionRepository(async_session_factory),
             queue_repo=PostgresQueueRepository(async_session_factory),

--- a/packages/infra/jukebotx_infra/suno/fallback_client.py
+++ b/packages/infra/jukebotx_infra/suno/fallback_client.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+from jukebotx_core.ports.suno_client import SunoClient, SunoTrackData
+
+from .client import HttpxSunoClient, SunoScrapeError
+
+_LOG = logging.getLogger(__name__)
+
+_REQUIRED_FIELDS: tuple[str, ...] = ("mp3_url",)
+_QUALITY_FIELDS: tuple[str, ...] = ("image_url", "title", "artist_display", "lyrics")
+
+
+class PyppeteerSunoClient(SunoClient):
+    """Fallback scraper using a browser runtime for pages that fail static scraping."""
+
+    async def fetch_track(self, suno_url: str) -> SunoTrackData:
+        try:
+            from pyppeteer import launch
+        except ImportError as exc:  # pragma: no cover - environment dependent
+            raise SunoScrapeError(
+                "pyppeteer is not installed for fallback scraping"
+            ) from exc
+
+        browser = await launch(
+            headless=True,
+            args=[
+                "--no-sandbox",
+                "--disable-setuid-sandbox",
+                "--disable-dev-shm-usage",
+            ],
+        )
+        try:
+            page = await browser.newPage()
+            await page.setUserAgent("Mozilla/5.0 (compatible; JukeBotx/1.0)")
+            response = await page.goto(
+                suno_url, waitUntil="networkidle2", timeout=45_000
+            )
+            if response is None:
+                raise SunoScrapeError(
+                    f"Fallback browser returned no response for URL: {suno_url}"
+                )
+            if response.status >= 400:
+                raise SunoScrapeError(
+                    f"Fallback browser fetch failed. URL: {suno_url}. Status: {response.status}"
+                )
+
+            payload = await page.evaluate(
+                """() => {
+                    const metaByProp = (prop) => {
+                        const el = document.querySelector(`meta[property="${prop}"]`);
+                        return el?.content || null;
+                    };
+                    const metaByName = (name) => {
+                        const el = document.querySelector(`meta[name="${name}"]`);
+                        return el?.content || null;
+                    };
+
+                    const description = metaByName("description") || metaByProp("og:description");
+                    const title = metaByProp("og:title") || document.title || null;
+
+                    return {
+                        title,
+                        description,
+                        image_url: metaByProp("og:image"),
+                        video_url: metaByProp("og:video"),
+                        mp3_url: metaByProp("og:audio"),
+                        final_url: window.location.href,
+                    };
+                }"""
+            )
+
+            title = payload.get("title")
+            artist_display = None
+            artist_username = None
+            description = payload.get("description")
+            if description and " by " in description:
+                left, right = description.split(" by ", 1)
+                title = title or left.strip() or None
+                artist_display = right.strip() or None
+
+            return SunoTrackData(
+                suno_url=payload.get("final_url") or suno_url,
+                title=title,
+                artist_display=artist_display,
+                artist_username=artist_username,
+                lyrics=None,
+                image_url=payload.get("image_url"),
+                video_url=payload.get("video_url"),
+                mp3_url=payload.get("mp3_url"),
+            )
+        finally:
+            await browser.close()
+
+
+class FallbackSunoClient(SunoClient):
+    """
+    Composite Suno client.
+
+    Strategy:
+    1) Fetch via primary Httpx client.
+    2) Validate required/quality fields.
+    3) On failure or incompleteness, fetch via fallback browser scraper.
+    4) Merge deterministically: keep primary non-empty values, fill gaps from fallback.
+    """
+
+    def __init__(
+        self,
+        *,
+        primary_client: SunoClient | None = None,
+        fallback_client: SunoClient | None = None,
+        quality_fields: Iterable[str] = _QUALITY_FIELDS,
+    ) -> None:
+        self._primary = primary_client or HttpxSunoClient()
+        self._fallback = fallback_client or PyppeteerSunoClient()
+        self._quality_fields = tuple(quality_fields)
+
+    async def fetch_track(self, suno_url: str) -> SunoTrackData:
+        primary_data: SunoTrackData | None = None
+        primary_error: Exception | None = None
+
+        try:
+            primary_data = await self._primary.fetch_track(suno_url)
+        except Exception as exc:  # pragma: no cover - tested via behavior
+            primary_error = exc
+
+        needs_fallback = (
+            primary_data is None
+            or self._missing_fields(primary_data, _REQUIRED_FIELDS)
+            or self._missing_fields(primary_data, self._quality_fields)
+        )
+
+        if not needs_fallback:
+            return primary_data
+
+        fallback_data: SunoTrackData | None = None
+        fallback_error: Exception | None = None
+        try:
+            fallback_data = await self._fallback.fetch_track(suno_url)
+        except Exception as exc:  # pragma: no cover - tested via behavior
+            fallback_error = exc
+
+        if primary_data is None and fallback_data is None:
+            if primary_error is not None:
+                raise SunoScrapeError(
+                    f"Primary Suno scrape failed: {primary_error!r}"
+                ) from primary_error
+            if fallback_error is not None:
+                raise SunoScrapeError(
+                    f"Fallback Suno scrape failed: {fallback_error!r}"
+                ) from fallback_error
+            raise SunoScrapeError(
+                "Both primary and fallback Suno scrapers returned no data"
+            )
+
+        if primary_data is None:
+            _LOG.info(
+                "suno_fetch_fallback_used reason=primary_failure url=%s", suno_url
+            )
+            assert fallback_data is not None
+            return fallback_data
+
+        if fallback_data is None:
+            _LOG.warning(
+                "suno_fetch_fallback_failed reason=primary_incomplete url=%s primary_missing=%s fallback_error=%r",
+                suno_url,
+                self._missing_field_names(
+                    primary_data, _REQUIRED_FIELDS + self._quality_fields
+                ),
+                fallback_error,
+            )
+            return primary_data
+
+        merged = self._merge(primary_data, fallback_data)
+        _LOG.info(
+            "suno_fetch_fallback_used reason=primary_incomplete url=%s primary_missing=%s",
+            suno_url,
+            self._missing_field_names(
+                primary_data, _REQUIRED_FIELDS + self._quality_fields
+            ),
+        )
+        return merged
+
+    @staticmethod
+    def _missing_fields(track: SunoTrackData, fields: Iterable[str]) -> bool:
+        return any(not getattr(track, field, None) for field in fields)
+
+    @staticmethod
+    def _missing_field_names(track: SunoTrackData, fields: Iterable[str]) -> list[str]:
+        return [field for field in fields if not getattr(track, field, None)]
+
+    @staticmethod
+    def _merge(primary: SunoTrackData, fallback: SunoTrackData) -> SunoTrackData:
+        return SunoTrackData(
+            suno_url=primary.suno_url or fallback.suno_url,
+            title=primary.title or fallback.title,
+            artist_display=primary.artist_display or fallback.artist_display,
+            artist_username=primary.artist_username or fallback.artist_username,
+            lyrics=primary.lyrics or fallback.lyrics,
+            image_url=primary.image_url or fallback.image_url,
+            video_url=primary.video_url or fallback.video_url,
+            mp3_url=primary.mp3_url or fallback.mp3_url,
+        )

--- a/tests/test_suno_fallback_client.py
+++ b/tests/test_suno_fallback_client.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import pytest
+
+from jukebotx_core.ports.suno_client import SunoTrackData
+from jukebotx_infra.suno.fallback_client import FallbackSunoClient
+
+
+class _StubClient:
+    def __init__(
+        self, data: SunoTrackData | None = None, error: Exception | None = None
+    ) -> None:
+        self._data = data
+        self._error = error
+        self.calls = 0
+
+    async def fetch_track(self, suno_url: str) -> SunoTrackData:
+        self.calls += 1
+        if self._error is not None:
+            raise self._error
+        assert self._data is not None
+        return self._data
+
+
+def _track(**kwargs) -> SunoTrackData:
+    base = dict(
+        suno_url="https://suno.com/song/abc",
+        title="title",
+        artist_display="artist",
+        artist_username="artist_u",
+        lyrics="lyrics",
+        image_url="https://img",
+        video_url="https://video",
+        mp3_url="https://mp3",
+    )
+    base.update(kwargs)
+    return SunoTrackData(**base)
+
+
+@pytest.mark.asyncio
+async def test_uses_primary_without_fallback_when_complete() -> None:
+    primary = _StubClient(data=_track())
+    fallback = _StubClient(data=_track(title="fallback"))
+
+    client = FallbackSunoClient(primary_client=primary, fallback_client=fallback)
+    result = await client.fetch_track("https://suno.com/song/abc")
+
+    assert result.title == "title"
+    assert primary.calls == 1
+    assert fallback.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_merges_missing_primary_fields_from_fallback() -> None:
+    primary = _StubClient(data=_track(title=None, image_url=None, mp3_url=None))
+    fallback = _StubClient(
+        data=_track(
+            title="fallback-title",
+            image_url="https://fallback-img",
+            mp3_url="https://fallback-mp3",
+        )
+    )
+
+    client = FallbackSunoClient(primary_client=primary, fallback_client=fallback)
+    result = await client.fetch_track("https://suno.com/song/abc")
+
+    assert result.title == "fallback-title"
+    assert result.image_url == "https://fallback-img"
+    assert result.mp3_url == "https://fallback-mp3"
+    assert result.artist_display == "artist"
+
+
+@pytest.mark.asyncio
+async def test_uses_fallback_on_primary_failure() -> None:
+    primary = _StubClient(error=RuntimeError("boom"))
+    fallback = _StubClient(data=_track(title="from-fallback"))
+
+    client = FallbackSunoClient(primary_client=primary, fallback_client=fallback)
+    result = await client.fetch_track("https://suno.com/song/abc")
+
+    assert result.title == "from-fallback"
+    assert primary.calls == 1
+    assert fallback.calls == 1


### PR DESCRIPTION
### Motivation
- The existing static `HttpxSunoClient` can return incomplete or failing metadata for some Suno pages, so a browser-based fallback improves coverage and quality.
- A deterministic merge strategy is required so the system prefers fast primary results but fills gaps from a reliable fallback without surprising overrides.
- Telemetry for fallback usage/failures is useful for monitoring scraper health and deciding when to rely on the heavier fallback path.

### Description
- Added a new infra module `packages/infra/jukebotx_infra/suno/fallback_client.py` that implements a `PyppeteerSunoClient` (lazy-imports `pyppeteer`) and a composite `FallbackSunoClient` implementing the `SunoClient` port, including required (`mp3_url`) and quality fields validation, deterministic merge (primary non-empty wins), and telemetry `logging` events. 
- Wired the bot to use the composite client by replacing the direct `HttpxSunoClient()` with `FallbackSunoClient()` in `apps/bot/jukebotx_bot/main.py` (`build_bot()` dependency construction).
- Added focused async unit tests at `tests/test_suno_fallback_client.py` covering primary-only success, merge-on-incomplete-primary, and primary-failure -> fallback behavior.

### Testing
- Attempted to run `pytest -q tests/test_suno_fallback_client.py tests/test_suno_client_meta.py`, but the run failed due to an environment plugin dependency (`pytest_asyncio` requiring missing `backports.asyncio`), so the async tests were not executed.
- Verified syntax by compiling with `python -m compileall` under the project Python (`PYENV_VERSION=3.11.14`), which succeeded for the new/modified files.
- Ran `black` to format changes and committed the changes; tests are present and designed to run in an environment with `pytest_asyncio` and its dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b789c65cc832fa9703abe0acde354)