### PR TITLE
Remove unused ingest_track stub and document canonical ingestion entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ This repo is set up so you can:
 
   * The “truth” of the system: entities, ports, use cases
   * No discord.py, no httpx, no infrastructure dependencies
+  * Canonical ingestion entry point: `jukebotx_core.use_cases.ingest_suno_links.IngestSunoLink`
 
 * **Infrastructure adapters** (`packages/infra`)
 

--- a/packages/core/jukebotx_core/use_cases/ingest_suno_links.py
+++ b/packages/core/jukebotx_core/use_cases/ingest_suno_links.py
@@ -1,4 +1,8 @@
-# packages/core/jukebotx_core/use_cases/ingest_suno_links.py
+"""Canonical track ingestion use case for Suno links.
+
+`IngestSunoLink` is the supported public ingestion entry point in core.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass


### PR DESCRIPTION
### Motivation
- Remove the unused empty stub `packages/core/jukebotx_core/use_cases/ingest_track.py` and clarify that `IngestSunoLink` is the canonical core ingestion entry point to avoid contributor confusion.

### Description
- Deleted the empty `packages/core/jukebotx_core/use_cases/ingest_track.py`, added a module docstring to `packages/core/jukebotx_core/use_cases/ingest_suno_links.py` describing `IngestSunoLink` as the supported public ingestion entry point, and updated `README.md` to reference `jukebotx_core.use_cases.ingest_suno_links.IngestSunoLink`.

### Testing
- Attempted to run `pytest tests/test_suno_ingest.py`, but the run failed in the current environment due to a missing `backports.asyncio` dependency; no other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c6c493c6c832f8ed1fc1fa301e2a3)