### PR TITLE
chore(compose): use env-defined host ports in development and production overlays

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,13 +1,13 @@
 services:
   db:
     ports:
-      - "${DB_PORT_HOST_DEV:-5432}:5432"
+      - "${DB_PORT_HOST_DEV}:5432"
 
   api:
     ports:
-      - "${API_PORT_HOST_DEV:-8001}:8000"
+      - "${API_PORT_HOST_DEV}:8000"
 
   minio:
     ports:
-      - "${MINIO_PORT_HOST_DEV:-9000}:9000"
-      - "${MINIO_CONSOLE_PORT_HOST_DEV:-9001}:9001"
+      - "${MINIO_PORT_HOST_DEV}:9000"
+      - "${MINIO_CONSOLE_PORT_HOST_DEV}:9001"

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,13 +1,13 @@
 services:
   db:
     ports:
-      - "${DB_PORT_HOST_PROD:-15432}:5432"
+      - "${DB_PORT_HOST_PROD}:5432"
 
   api:
     ports:
-      - "${API_PORT_HOST_PROD:-18001}:8000"
+      - "${API_PORT_HOST_PROD}:8000"
 
   minio:
     ports:
-      - "${MINIO_PORT_HOST_PROD:-19000}:9000"
-      - "${MINIO_CONSOLE_PORT_HOST_PROD:-19001}:9001"
+      - "${MINIO_PORT_HOST_PROD}:9000"
+      - "${MINIO_CONSOLE_PORT_HOST_PROD}:9001"


### PR DESCRIPTION
### Motivation

- Ensure Compose overlays read host-port settings from the repository environment files so host ports don’t collide when running multiple stacks.  
- Remove inline fallback literals in overlays so the `.env.example` / `.env` values are authoritative for dev and prod port mappings.

### Description

- Updated `docker-compose.development.yml` to map host ports using `DB_PORT_HOST_DEV`, `API_PORT_HOST_DEV`, `MINIO_PORT_HOST_DEV`, and `MINIO_CONSOLE_PORT_HOST_DEV` from the environment.  
- Updated `docker-compose.production.yml` to map host ports using `DB_PORT_HOST_PROD`, `API_PORT_HOST_PROD`, `MINIO_PORT_HOST_PROD`, and `MINIO_CONSOLE_PORT_HOST_PROD` from the environment.  
- Removed inline fallback defaults (e.g. `:-5432`) so Compose always honors the environment-defined variables in `.env.example` / `.env`.

### Testing

- Attempted to validate resulting Compose configurations with `docker compose --env-file .env.example -f docker-compose.yml -f docker-compose.development.yml config` and the equivalent production command, but the check failed because `docker` is not installed in this execution environment (test could not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a544d3a680832fa5fa5d149794f32d)