### PR TITLE
chore(compose): add dev_ prefix for development containers

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,13 +1,22 @@
 services:
   db:
+    container_name: dev_db
     ports:
       - "${DB_PORT_HOST_DEV}:5432"
 
   api:
+    container_name: dev_api
     ports:
       - "${API_PORT_HOST_DEV}:8000"
 
+  worker:
+    container_name: dev_worker
+
+  bot:
+    container_name: dev_bot
+
   minio:
+    container_name: dev_minio
     ports:
       - "${MINIO_PORT_HOST_DEV}:9000"
       - "${MINIO_CONSOLE_PORT_HOST_DEV}:9001"


### PR DESCRIPTION
### Motivation
- Make development container names explicit and distinct to avoid collisions and make local tooling and debugging more predictable.

### Description
- Added `container_name` entries with a `dev_` prefix for the development services in `docker-compose.development.yml` for `db`, `api`, `worker`, `bot`, and `minio`.

### Testing
- Attempted to run compose validation with `docker compose -f docker-compose.yml -f docker-compose.development.yml config`, but validation could not be executed because `docker` is not available in this environment (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a546cd7158832fba39e441c38808ea)