### PR TITLE
Fix voice reconnect loop when using ;join

### DIFF
--- a/apps/bot/jukebotx_bot/main.py
+++ b/apps/bot/jukebotx_bot/main.py
@@ -385,9 +385,30 @@ class JukeBot(commands.Bot):
                 return
 
             channel = ctx.author.voice.channel
+            voice_client = ctx.guild.voice_client
+
+            if voice_client is not None:
+                if voice_client.channel and voice_client.channel.id == channel.id:
+                    await ctx.send(f"I'm already in {channel.name}.")
+                    return
+
+                if voice_client.is_connected():
+                    await voice_client.move_to(channel)
+                    await ctx.send(f"Moved to {channel.name}!")
+                    return
+
+                # A stale/disconnected voice client can cause reconnect loops.
+                try:
+                    await voice_client.disconnect(force=True)
+                except Exception:
+                    logging.warning(
+                        "Failed to force-disconnect stale voice client for guild %s",
+                        ctx.guild.id,
+                        exc_info=True,
+                    )
 
             try:
-                await channel.connect()
+                await channel.connect(reconnect=False)
             except discord.Forbidden:
                 await ctx.send("🚫 I don't have permission to join that voice channel (View/Connect).")
                 return


### PR DESCRIPTION
## Summary
- harden `;join` handling around existing guild voice clients
- avoid reconnect loops by cleaning up stale/disconnected voice client state before reconnecting
- prevent unnecessary reconnect attempts when the bot is already in the caller's channel
- move active connections with `move_to` instead of opening a second connection
- set `channel.connect(reconnect=False)` to fail fast on handshake failures rather than looping retries

## Details
The bot previously always called `channel.connect()` for `;join`. If discord.py still had a stale voice client attached to the guild, this could trigger repeated voice handshake retries and disconnect/rejoin behavior.

The new flow:
1. Read `ctx.guild.voice_client`.
2. If already in target channel, return with an informative message.
3. If connected to another channel, `move_to` the target channel.
4. If the voice client exists but is not connected, force-disconnect stale state.
5. Connect with `reconnect=False`.

## Files changed
- `apps/bot/jukebotx_bot/main.py`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7bfe82050832fb4ed980cf60aa7b8)