### PR TITLE
Introduce playback backend port and move FFmpeg transport behind it

### DIFF
--- a/apps/bot/jukebotx_bot/discord/audio.py
+++ b/apps/bot/jukebotx_bot/discord/audio.py
@@ -5,7 +5,6 @@ import json
 import logging
 import os
 import subprocess
-import threading
 from typing import Optional
 
 import httpx
@@ -14,6 +13,8 @@ import discord
 
 from jukebotx_bot.discord.now_playing import build_now_playing_embed
 from jukebotx_bot.discord.session import SessionState, Track
+from jukebotx_bot.voice.backends.base import PlaybackBackend
+from jukebotx_bot.voice.backends.discord_ffmpeg import DiscordFFmpegPlaybackBackend
 from jukebotx_infra.suno.client import HttpxSunoClient, SunoScrapeError
 
 
@@ -26,18 +27,18 @@ _FFPROBE_PATH = os.getenv("FFPROBE_PATH", "ffprobe")
 
 
 class GuildAudioController:
-    def __init__(self, guild_id: int, session: SessionState) -> None:
+    def __init__(self, guild_id: int, session: SessionState, *, backend: PlaybackBackend | None = None) -> None:
         self.guild_id = guild_id
         self.session = session
         self._lock = asyncio.Lock()
-        self._current_source: Optional[discord.FFmpegOpusAudio] = None
-        self._stderr_thread: Optional[threading.Thread] = None
-        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._backend = backend or DiscordFFmpegPlaybackBackend(guild_id)
+        self._backend.add_track_end_hook(self._on_track_end)
+        self._current_source: Optional[object] = None
         self._suno_client = HttpxSunoClient()
 
     async def play_next(self, voice_client: discord.VoiceClient) -> Track | None:
         async with self._lock:
-            if voice_client.is_playing() or voice_client.is_paused():
+            if self._backend.is_playing(voice_client):
                 return None
 
             track = self.session.start_next_track()
@@ -49,32 +50,18 @@ class GuildAudioController:
             track.duration_seconds = await self._probe_duration_seconds(playback_url)
 
             try:
-                source = self._build_source(playback_url)
+                source = await self._backend.play_track(voice_client, playback_url)
             except ValueError as exc:
                 logger.error("Refusing to play invalid audio URL for guild %s: %s", self.guild_id, exc)
                 self.session.stop_playback()
                 return None
             self._current_source = source
-
-            if self._loop is None:
-                self._loop = asyncio.get_running_loop()
-
-            def _after_playback(error: Exception | None, *, current_source=source) -> None:
-                if self._loop is None:
-                    return
-                asyncio.run_coroutine_threadsafe(
-                    self._on_track_end(voice_client, current_source, error),
-                    self._loop,
-                )
-
-            voice_client.play(source, after=_after_playback)
             return track
 
     async def stop(self, voice_client: discord.VoiceClient) -> None:
         async with self._lock:
-            if voice_client.is_playing() or voice_client.is_paused():
-                voice_client.stop()
-            await self._cleanup_ffmpeg()
+            await self._backend.stop(voice_client)
+            self._current_source = None
             self.session.stop_playback()
 
     async def skip(self, voice_client: discord.VoiceClient) -> Track | None:
@@ -84,7 +71,7 @@ class GuildAudioController:
     async def _on_track_end(
         self,
         voice_client: discord.VoiceClient,
-        source: discord.FFmpegOpusAudio,
+        source: object,
         error: Exception | None,
     ) -> None:
         if error is not None:
@@ -93,7 +80,7 @@ class GuildAudioController:
         async with self._lock:
             if self._current_source is not source:
                 return
-            await self._cleanup_ffmpeg()
+            self._current_source = None
             self.session.stop_playback()
 
         self._log_track_end(error)
@@ -160,27 +147,6 @@ class GuildAudioController:
                 if asyncio.get_running_loop().time() >= deadline:
                     return
                 await asyncio.sleep(_OPUS_READY_POLL_SECONDS)
-
-    def _build_source(self, url: str) -> discord.FFmpegOpusAudio:
-        self._assert_audio_url(url)
-        source = discord.FFmpegOpusAudio(
-            url,
-            before_options="-reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5",
-            options="-vn",
-            stderr=subprocess.PIPE,
-        )
-        self._start_ffmpeg_logger(source)
-        return source
-
-    def _assert_audio_url(self, url: str) -> None:
-        lowered = url.lower()
-        stripped = lowered.split("?", 1)[0]
-        if not lowered.startswith("http"):
-            raise ValueError(f"Audio URL must be http(s): {url}")
-        if "suno.com/song/" in lowered or "suno.com/s/" in lowered:
-            raise ValueError(f"Refusing to pass Suno page URL to ffmpeg: {url}")
-        if not (stripped.endswith(".mp3") or stripped.endswith(".opus") or stripped.endswith("/opus") or "cdn" in lowered):
-            raise ValueError(f"Refusing to pass non-audio URL to ffmpeg: {url}")
 
     async def _resolve_playback_url(self, track: Track) -> str:
         url = track.opus_url or track.audio_url
@@ -265,55 +231,6 @@ class GuildAudioController:
                 current.title,
                 f" error={error}" if error else "",
             )
-
-    def _start_ffmpeg_logger(self, source: discord.FFmpegOpusAudio) -> None:
-        process = getattr(source, "process", None)
-        if process is None or process.stderr is None:
-            return
-
-        def _read_stderr() -> None:
-            for raw_line in iter(process.stderr.readline, b""):
-                if not raw_line:
-                    break
-                line = raw_line.decode(errors="replace").rstrip()
-                if line:
-                    logger.warning("FFmpeg stderr [guild=%s]: %s", self.guild_id, line)
-
-        self._stderr_thread = threading.Thread(
-            target=_read_stderr,
-            name=f"ffmpeg-stderr-{self.guild_id}",
-            daemon=True,
-        )
-        self._stderr_thread.start()
-
-    async def _cleanup_ffmpeg(self) -> None:
-        source = self._current_source
-        if source is None:
-            return
-
-        process = getattr(source, "process", None)
-        if process is not None:
-            try:
-                if process.stdin is not None:
-                    process.stdin.close()
-            except Exception as exc:  # pragma: no cover - defensive
-                logger.warning("Failed to close ffmpeg stdin: %s", exc)
-
-            try:
-                process.terminate()
-                process.wait(timeout=2)
-            except subprocess.TimeoutExpired:
-                process.kill()
-                process.wait(timeout=2)
-            except Exception as exc:  # pragma: no cover - defensive
-                logger.warning("Failed to terminate ffmpeg process: %s", exc)
-
-        try:
-            source.cleanup()
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.warning("Failed to cleanup ffmpeg source: %s", exc)
-
-        self._current_source = None
 
 
 class AudioControllerManager:

--- a/apps/bot/jukebotx_bot/voice/backends/__init__.py
+++ b/apps/bot/jukebotx_bot/voice/backends/__init__.py
@@ -1,0 +1,4 @@
+from jukebotx_bot.voice.backends.base import PlaybackBackend
+from jukebotx_bot.voice.backends.discord_ffmpeg import DiscordFFmpegPlaybackBackend
+
+__all__ = ["PlaybackBackend", "DiscordFFmpegPlaybackBackend"]

--- a/apps/bot/jukebotx_bot/voice/backends/base.py
+++ b/apps/bot/jukebotx_bot/voice/backends/base.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import discord
+
+TrackEndHook = Callable[["discord.VoiceClient", object, Exception | None], Awaitable[None] | None]
+
+
+class PlaybackBackend(ABC):
+    @abstractmethod
+    async def connect(self, channel: "discord.VocalGuildChannel") -> "discord.VoiceClient":
+        raise NotImplementedError
+
+    @abstractmethod
+    async def disconnect(self, voice_client: "discord.VoiceClient") -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def play_track(self, voice_client: "discord.VoiceClient", url: str) -> object:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def stop(self, voice_client: "discord.VoiceClient") -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def skip(self, voice_client: "discord.VoiceClient") -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def is_playing(self, voice_client: "discord.VoiceClient") -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def add_track_end_hook(self, hook: TrackEndHook) -> None:
+        raise NotImplementedError

--- a/apps/bot/jukebotx_bot/voice/backends/discord_ffmpeg.py
+++ b/apps/bot/jukebotx_bot/voice/backends/discord_ffmpeg.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import subprocess
+import threading
+
+import discord
+
+from jukebotx_bot.voice.backends.base import PlaybackBackend, TrackEndHook
+
+
+logger = logging.getLogger(__name__)
+
+
+class DiscordFFmpegPlaybackBackend(PlaybackBackend):
+    def __init__(self, guild_id: int) -> None:
+        self.guild_id = guild_id
+        self._current_source: discord.FFmpegOpusAudio | None = None
+        self._stderr_thread: threading.Thread | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._track_end_hooks: list[TrackEndHook] = []
+
+    async def connect(self, channel: discord.VocalGuildChannel) -> discord.VoiceClient:
+        return await channel.connect()
+
+    async def disconnect(self, voice_client: discord.VoiceClient) -> None:
+        await self._cleanup_current_source()
+        if voice_client.is_connected():
+            await voice_client.disconnect()
+
+    async def play_track(self, voice_client: discord.VoiceClient, url: str) -> object:
+        source = self._build_source(url)
+        self._current_source = source
+
+        if self._loop is None:
+            self._loop = asyncio.get_running_loop()
+
+        def _after_playback(error: Exception | None, *, current_source=source) -> None:
+            if self._loop is None:
+                return
+            asyncio.run_coroutine_threadsafe(
+                self._dispatch_track_end(voice_client, current_source, error),
+                self._loop,
+            )
+
+        voice_client.play(source, after=_after_playback)
+        return source
+
+    async def stop(self, voice_client: discord.VoiceClient) -> None:
+        if voice_client.is_playing() or voice_client.is_paused():
+            voice_client.stop()
+        await self._cleanup_current_source()
+
+    async def skip(self, voice_client: discord.VoiceClient) -> None:
+        await self.stop(voice_client)
+
+    def is_playing(self, voice_client: discord.VoiceClient) -> bool:
+        return voice_client.is_playing() or voice_client.is_paused()
+
+    def add_track_end_hook(self, hook: TrackEndHook) -> None:
+        self._track_end_hooks.append(hook)
+
+    async def _dispatch_track_end(
+        self,
+        voice_client: discord.VoiceClient,
+        source: discord.FFmpegOpusAudio,
+        error: Exception | None,
+    ) -> None:
+        if self._current_source is source:
+            await self._cleanup_source(source)
+            self._current_source = None
+
+        for hook in self._track_end_hooks:
+            result = hook(voice_client, source, error)
+            if inspect.isawaitable(result):
+                await result
+
+    def _build_source(self, url: str) -> discord.FFmpegOpusAudio:
+        self._assert_audio_url(url)
+        source = discord.FFmpegOpusAudio(
+            url,
+            before_options="-reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5",
+            options="-vn",
+            stderr=subprocess.PIPE,
+        )
+        self._start_ffmpeg_logger(source)
+        return source
+
+    def _assert_audio_url(self, url: str) -> None:
+        lowered = url.lower()
+        stripped = lowered.split("?", 1)[0]
+        if not lowered.startswith("http"):
+            raise ValueError(f"Audio URL must be http(s): {url}")
+        if "suno.com/song/" in lowered or "suno.com/s/" in lowered:
+            raise ValueError(f"Refusing to pass Suno page URL to ffmpeg: {url}")
+        if not (stripped.endswith(".mp3") or stripped.endswith(".opus") or stripped.endswith("/opus") or "cdn" in lowered):
+            raise ValueError(f"Refusing to pass non-audio URL to ffmpeg: {url}")
+
+    def _start_ffmpeg_logger(self, source: discord.FFmpegOpusAudio) -> None:
+        process = getattr(source, "process", None)
+        if process is None or process.stderr is None:
+            return
+
+        def _read_stderr() -> None:
+            for raw_line in iter(process.stderr.readline, b""):
+                if not raw_line:
+                    break
+                line = raw_line.decode(errors="replace").rstrip()
+                if line:
+                    logger.warning("FFmpeg stderr [guild=%s]: %s", self.guild_id, line)
+
+        self._stderr_thread = threading.Thread(
+            target=_read_stderr,
+            name=f"ffmpeg-stderr-{self.guild_id}",
+            daemon=True,
+        )
+        self._stderr_thread.start()
+
+    async def _cleanup_current_source(self) -> None:
+        source = self._current_source
+        if source is None:
+            return
+        await self._cleanup_source(source)
+        self._current_source = None
+
+    async def _cleanup_source(self, source: discord.FFmpegOpusAudio) -> None:
+        process = getattr(source, "process", None)
+        if process is not None:
+            try:
+                if process.stdin is not None:
+                    process.stdin.close()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("Failed to close ffmpeg stdin: %s", exc)
+
+            try:
+                process.terminate()
+                process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=2)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("Failed to terminate ffmpeg process: %s", exc)
+
+        try:
+            source.cleanup()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Failed to cleanup ffmpeg source: %s", exc)

--- a/tests/test_audio_controller.py
+++ b/tests/test_audio_controller.py
@@ -1,10 +1,7 @@
-import subprocess
 from pathlib import Path
 import sys
 
 import pytest
-
-import discord
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.extend(
@@ -17,127 +14,110 @@ sys.path.extend(
 
 from jukebotx_bot.discord.audio import GuildAudioController
 from jukebotx_bot.discord.session import SessionState, Track
-
-
-class FakeStdin:
-    def __init__(self) -> None:
-        self.closed = False
-
-    def close(self) -> None:
-        self.closed = True
-
-
-class FakeProcess:
-    def __init__(self, *, raise_timeout: bool = False) -> None:
-        self.stdin = FakeStdin()
-        self.stderr = None
-        self._raise_timeout = raise_timeout
-        self.terminated = False
-        self.killed = False
-
-    def terminate(self) -> None:
-        self.terminated = True
-
-    def kill(self) -> None:
-        self.killed = True
-
-    def wait(self, timeout: float | None = None) -> int:
-        if self._raise_timeout and not self.killed:
-            raise subprocess.TimeoutExpired(cmd="ffmpeg", timeout=timeout or 0)
-        return 0
-
-
-class FakeFFmpegPCMAudio:
-    def __init__(self, url: str, *, before_options: str, options: str, stderr) -> None:
-        self.url = url
-        self.before_options = before_options
-        self.options = options
-        self.process = FakeProcess(raise_timeout=True)
-        self.cleanup_called = False
-
-    def cleanup(self) -> None:
-        self.cleanup_called = True
+from jukebotx_bot.voice.backends.base import PlaybackBackend, TrackEndHook
 
 
 class FakeVoiceClient:
     def __init__(self) -> None:
-        self._playing = False
-        self._paused = False
-        self.stop_called = False
-        self.play_calls: list[discord.AudioSource] = []
+        self.playing = False
 
-    def is_playing(self) -> bool:
-        return self._playing
 
-    def is_paused(self) -> bool:
-        return self._paused
+class FakePlaybackBackend(PlaybackBackend):
+    def __init__(self) -> None:
+        self.play_calls: list[tuple[FakeVoiceClient, str]] = []
+        self.stop_calls = 0
+        self._hooks: list[TrackEndHook] = []
+        self._next_source = 0
 
-    def play(self, source: discord.AudioSource, after) -> None:
-        self._playing = True
-        self.play_calls.append(source)
-        self.after_callback = after
+    async def connect(self, channel):
+        raise NotImplementedError
 
-    def stop(self) -> None:
-        self._playing = False
-        self.stop_called = True
+    async def disconnect(self, voice_client):
+        raise NotImplementedError
+
+    async def play_track(self, voice_client, url: str) -> object:
+        voice_client.playing = True
+        self._next_source += 1
+        source = f"source-{self._next_source}"
+        self.play_calls.append((voice_client, url))
+        return source
+
+    async def stop(self, voice_client) -> None:
+        voice_client.playing = False
+        self.stop_calls += 1
+
+    async def skip(self, voice_client) -> None:
+        await self.stop(voice_client)
+
+    def is_playing(self, voice_client) -> bool:
+        return voice_client.playing
+
+    def add_track_end_hook(self, hook: TrackEndHook) -> None:
+        self._hooks.append(hook)
+
+    async def emit_track_end(self, voice_client, source: object, error: Exception | None = None) -> None:
+        for hook in self._hooks:
+            result = hook(voice_client, source, error)
+            if result is not None:
+                await result
+
+
+def _build_track(title: str, requester_id: int, requester_name: str) -> Track:
+    return Track(
+        audio_url=f"https://example.com/{title}.mp3",
+        opus_url=None,
+        page_url=None,
+        title=title,
+        artist_display=None,
+        media_url=None,
+        requester_id=requester_id,
+        requester_name=requester_name,
+    )
 
 
 @pytest.mark.asyncio
-async def test_play_next_starts_track(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(discord, "FFmpegPCMAudio", FakeFFmpegPCMAudio)
-
+async def test_play_next_starts_track() -> None:
     session = SessionState()
-    session.queue.append(
-        Track(url="https://example.com/track1", title="Track 1", requester_id=1, requester_name="User")
-    )
-    controller = GuildAudioController(guild_id=123, session=session)
+    session.queue.append(_build_track("track1", 1, "User"))
+    backend = FakePlaybackBackend()
+    controller = GuildAudioController(guild_id=123, session=session, backend=backend)
     voice_client = FakeVoiceClient()
 
     started = await controller.play_next(voice_client)
 
     assert started is not None
-    assert started.title == "Track 1"
-    assert voice_client.is_playing()
-    assert voice_client.play_calls
+    assert started.title == "track1"
+    assert voice_client.playing
+    assert len(backend.play_calls) == 1
 
 
 @pytest.mark.asyncio
-async def test_stop_cleans_up_ffmpeg(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(discord, "FFmpegPCMAudio", FakeFFmpegPCMAudio)
-
+async def test_stop_uses_backend_and_resets_session() -> None:
     session = SessionState()
-    session.queue.append(
-        Track(url="https://example.com/track1", title="Track 1", requester_id=1, requester_name="User")
-    )
-    controller = GuildAudioController(guild_id=123, session=session)
+    session.queue.append(_build_track("track1", 1, "User"))
+    backend = FakePlaybackBackend()
+    controller = GuildAudioController(guild_id=123, session=session, backend=backend)
     voice_client = FakeVoiceClient()
 
     await controller.play_next(voice_client)
     source = controller._current_source
     assert source is not None
+
     await controller.stop(voice_client)
 
-    assert voice_client.stop_called
+    assert backend.stop_calls == 1
     assert controller._current_source is None
-    assert source.cleanup_called
-    assert source.process.stdin.closed
-    assert source.process.terminated
-    assert source.process.killed
+    assert session.now_playing is None
 
 
 @pytest.mark.asyncio
-async def test_track_end_autoplays_next(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(discord, "FFmpegPCMAudio", FakeFFmpegPCMAudio)
-
+async def test_track_end_autoplays_next() -> None:
     session = SessionState()
     session.autoplay_enabled = True
-    session.queue.append(
-        Track(url="https://example.com/track1", title="Track 1", requester_id=1, requester_name="User")
-    )
-    session.queue.append(
-        Track(url="https://example.com/track2", title="Track 2", requester_id=2, requester_name="User2")
-    )
-    controller = GuildAudioController(guild_id=123, session=session)
+    session.queue.append(_build_track("track1", 1, "User"))
+    session.queue.append(_build_track("track2", 2, "User2"))
+    backend = FakePlaybackBackend()
+    controller = GuildAudioController(guild_id=123, session=session, backend=backend)
     voice_client = FakeVoiceClient()
 
     first = await controller.play_next(voice_client)
@@ -145,9 +125,9 @@ async def test_track_end_autoplays_next(monkeypatch: pytest.MonkeyPatch) -> None
     current_source = controller._current_source
     assert current_source is not None
 
-    voice_client._playing = False
-    await controller._on_track_end(voice_client, current_source, None)
+    voice_client.playing = False
+    await backend.emit_track_end(voice_client, current_source)
 
     assert session.now_playing is not None
-    assert session.now_playing.title == "Track 2"
-    assert len(voice_client.play_calls) == 2
+    assert session.now_playing.title == "track2"
+    assert len(backend.play_calls) == 2


### PR DESCRIPTION
### Motivation
- Isolate playback transport behind a well-defined port so the audio controller can be backend-agnostic while preserving existing queue/session logic.
- Move existing Discord + FFmpeg specifics into a concrete transport to reduce migration risk and make future transports (e.g., alternate players) pluggable.

### Description
- Added a playback backend port `PlaybackBackend` with lifecycle/playback methods and a track-end hook contract in `apps/bot/jukebotx_bot/voice/backends/base.py` (methods: `connect`, `disconnect`, `play_track`, `stop`, `skip`, `is_playing`, and `add_track_end_hook`).
- Implemented `DiscordFFmpegPlaybackBackend` in `apps/bot/jukebotx_bot/voice/backends/discord_ffmpeg.py` which preserves current FFmpeg behavior (URL validation, building `discord.FFmpegOpusAudio`, `after` callback wiring to dispatch track-end hooks, ffmpeg stderr logging thread, and cleanup/termination semantics).
- Refactored `GuildAudioController` (`apps/bot/jukebotx_bot/discord/audio.py`) to depend on the `PlaybackBackend` interface for playback operations (`is_playing`, `play_track`, `stop`) and registered the controller's `_on_track_end` handler with the backend; controller still owns `SessionState` progression and autoplay/DJ sequencing.
- Exported backend types in `apps/bot/jukebotx_bot/voice/backends/__init__.py` and updated `tests/test_audio_controller.py` to exercise the controller through a fake `PlaybackBackend` rather than stubbing FFmpeg internals.

### Testing
- Compiled the changed modules with `python -m compileall apps/bot/jukebotx_bot/discord/audio.py apps/bot/jukebotx_bot/voice/backends tests/test_audio_controller.py` and compilation succeeded.
- Attempted to run `pytest -q tests/test_audio_controller.py` but the run failed in this environment due to a missing test dependency (`pytest_asyncio` transitively requires `backports.asyncio`), so automated test execution could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abd1de5eb4832fa9bd079695a26cc2)