### PR TITLE
Add voice orchestration service and backend-selectable routing

### DIFF
--- a/apps/bot/jukebotx_bot/discord/audio.py
+++ b/apps/bot/jukebotx_bot/discord/audio.py
@@ -15,6 +15,7 @@ from jukebotx_bot.discord.now_playing import build_now_playing_embed
 from jukebotx_bot.discord.session import SessionState, Track
 from jukebotx_bot.voice.backends.base import PlaybackBackend
 from jukebotx_bot.voice.backends.discord_ffmpeg import DiscordFFmpegPlaybackBackend
+from jukebotx_bot.voice.backends.lavalink import LavalinkPlaybackBackend
 from jukebotx_infra.suno.client import HttpxSunoClient, SunoScrapeError
 
 
@@ -57,6 +58,12 @@ class GuildAudioController:
                 return None
             self._current_source = source
             return track
+
+    async def connect(self, channel: discord.VocalGuildChannel) -> discord.VoiceClient:
+        return await self._backend.connect(channel)
+
+    async def disconnect(self, voice_client: discord.VoiceClient) -> None:
+        await self._backend.disconnect(voice_client)
 
     async def stop(self, voice_client: discord.VoiceClient) -> None:
         async with self._lock:
@@ -234,10 +241,20 @@ class GuildAudioController:
 
 
 class AudioControllerManager:
-    def __init__(self) -> None:
+    def __init__(self, *, backend_name: str = "ffmpeg") -> None:
         self._controllers: dict[int, GuildAudioController] = {}
+        self._backend_name = backend_name.strip().lower()
 
     def for_guild(self, guild_id: int, session: SessionState) -> GuildAudioController:
         if guild_id not in self._controllers:
-            self._controllers[guild_id] = GuildAudioController(guild_id, session)
+            self._controllers[guild_id] = GuildAudioController(
+                guild_id,
+                session,
+                backend=self._create_backend(guild_id),
+            )
         return self._controllers[guild_id]
+
+    def _create_backend(self, guild_id: int) -> PlaybackBackend:
+        if self._backend_name == "lavalink":
+            return LavalinkPlaybackBackend(guild_id)
+        return DiscordFFmpegPlaybackBackend(guild_id)

--- a/apps/bot/jukebotx_bot/main.py
+++ b/apps/bot/jukebotx_bot/main.py
@@ -21,6 +21,7 @@ from jukebotx_bot.discord.now_playing import build_now_playing_embed
 from jukebotx_bot.discord.session import SessionManager, Track
 from jukebotx_bot.discord.suno import extract_suno_urls
 from jukebotx_bot.settings import load_bot_settings
+from jukebotx_bot.voice.service import JoinResult, VoiceOrchestrationService
 from jukebotx_core.use_cases.ingest_suno_links import IngestSunoLink, IngestSunoLinkInput
 from jukebotx_infra.db import async_session_factory, init_db
 from jukebotx_infra.repos.queue_repo import PostgresQueueRepository
@@ -52,6 +53,7 @@ class BotDeps:
     playlist_client: HttpxSunoPlaylistClient
     submission_repo: PostgresSubmissionRepository
     queue_repo: PostgresQueueRepository
+    voice_service: VoiceOrchestrationService
 
 
 class JukeBot(commands.Bot):
@@ -102,6 +104,9 @@ class JukeBot(commands.Bot):
 
     def _get_audio(self, ctx: commands.Context) -> AudioControllerManager:
         return self.deps.audio_manager
+
+    def _get_voice(self, ctx: commands.Context) -> VoiceOrchestrationService:
+        return self.deps.voice_service
 
     def _build_opus_url(self, track_id: UUID | None) -> str | None:
         if track_id is None or self.settings.opus_api_base_url is None:
@@ -385,30 +390,8 @@ class JukeBot(commands.Bot):
                 return
 
             channel = ctx.author.voice.channel
-            voice_client = ctx.guild.voice_client
-
-            if voice_client is not None:
-                if voice_client.channel and voice_client.channel.id == channel.id:
-                    await ctx.send(f"I'm already in {channel.name}.")
-                    return
-
-                if voice_client.is_connected():
-                    await voice_client.move_to(channel)
-                    await ctx.send(f"Moved to {channel.name}!")
-                    return
-
-                # A stale/disconnected voice client can cause reconnect loops.
-                try:
-                    await voice_client.disconnect(force=True)
-                except Exception:
-                    logging.warning(
-                        "Failed to force-disconnect stale voice client for guild %s",
-                        ctx.guild.id,
-                        exc_info=True,
-                    )
-
             try:
-                await channel.connect(reconnect=False)
+                outcome = await self._get_voice(ctx).join(ctx.guild, channel)
             except discord.Forbidden:
                 await ctx.send("🚫 I don't have permission to join that voice channel (View/Connect).")
                 return
@@ -416,7 +399,15 @@ class JukeBot(commands.Bot):
                 await ctx.send(f"⚠️ Failed to join VC: {type(exc).__name__}: {exc}")
                 raise
 
-            await ctx.send(f"Joined {channel.name}!")
+            if outcome.result == JoinResult.ALREADY_IN_CHANNEL:
+                await ctx.send(f"I'm already in {outcome.channel_name}.")
+                return
+
+            if outcome.result == JoinResult.MOVED:
+                await ctx.send(f"Moved to {outcome.channel_name}!")
+                return
+
+            await ctx.send(f"Joined {outcome.channel_name}!")
 
 
         @self.command(name="leave")
@@ -432,10 +423,7 @@ class JukeBot(commands.Bot):
             session = self._get_session(ctx).for_guild(ctx.guild.id)
             session.reset()
 
-            if ctx.voice_client is not None:
-                audio = self._get_audio(ctx).for_guild(ctx.guild.id, session)
-                await audio.stop(ctx.voice_client)
-                await ctx.voice_client.disconnect()
+            await self._get_voice(ctx).leave(ctx.guild)
 
             await self.deps.queue_repo.clear(guild_id=ctx.guild.id)
             await self.deps.submission_repo.clear_for_channel(
@@ -690,8 +678,7 @@ class JukeBot(commands.Bot):
             )
 
             if session.autoplay_enabled and session.now_playing is None and ctx.voice_client is not None:
-                audio = self._get_audio(ctx).for_guild(ctx.guild.id, session)
-                started = await audio.play_next(ctx.voice_client)
+                started = await self._get_voice(ctx).play_next(ctx.guild)
                 if started is not None:
                     session.now_playing_channel_id = ctx.channel.id
                     embed = build_now_playing_embed(started)
@@ -751,7 +738,6 @@ class JukeBot(commands.Bot):
 
             session = self._get_session(ctx).for_guild(ctx.guild.id)
             session.now_playing_channel_id = ctx.channel.id
-            audio = self._get_audio(ctx).for_guild(ctx.guild.id, session)
             if session.now_playing is not None:
                 await ctx.send(f"Already playing: {session.now_playing.title}. Use ;n to skip.")
                 return
@@ -765,7 +751,7 @@ class JukeBot(commands.Bot):
                     await ctx.send("Queue is empty. Drop a Suno URL.")
                 return
 
-            started = await audio.play_next(ctx.voice_client)
+            started = await self._get_voice(ctx).play_next(ctx.guild)
             if started is None:
                 if isinstance(ctx.author, discord.Member) and _is_mod(ctx.author):
                     await ctx.send(
@@ -794,8 +780,7 @@ class JukeBot(commands.Bot):
                 return
 
             session = self._get_session(ctx).for_guild(ctx.guild.id)
-            audio = self._get_audio(ctx).for_guild(ctx.guild.id, session)
-            started = await audio.skip(ctx.voice_client)
+            started = await self._get_voice(ctx).skip(ctx.guild)
             if started is None:
                 await ctx.send("Skipped. Queue is now empty; playback stopped.")
                 return
@@ -818,9 +803,7 @@ class JukeBot(commands.Bot):
                 await ctx.send("I'm not connected to a voice channel.")
                 return
 
-            session = self._get_session(ctx).for_guild(ctx.guild.id)
-            audio = self._get_audio(ctx).for_guild(ctx.guild.id, session)
-            await audio.stop(ctx.voice_client)
+            await self._get_voice(ctx).stop(ctx.guild)
             await ctx.send("Playback stopped.")
 
         @self.command(name="clear")
@@ -993,9 +976,12 @@ def build_bot() -> JukeBot:
     intents = discord.Intents.default()
     intents.message_content = True  # required for prefix commands
 
+    session_manager = SessionManager()
+    audio_manager = AudioControllerManager(backend_name=settings.voice_backend)
+
     deps = BotDeps(
-        session_manager=SessionManager(),
-        audio_manager=AudioControllerManager(),
+        session_manager=session_manager,
+        audio_manager=audio_manager,
         ingest_use_case=IngestSunoLink(
             suno_client=HttpxSunoClient(),
             track_repo=PostgresTrackRepository(async_session_factory),
@@ -1005,6 +991,10 @@ def build_bot() -> JukeBot:
         playlist_client=HttpxSunoPlaylistClient(),
         submission_repo=PostgresSubmissionRepository(async_session_factory),
         queue_repo=PostgresQueueRepository(async_session_factory),
+        voice_service=VoiceOrchestrationService(
+            session_manager=session_manager,
+            audio_manager=audio_manager,
+        ),
     )
 
     return JukeBot(

--- a/apps/bot/jukebotx_bot/settings.py
+++ b/apps/bot/jukebotx_bot/settings.py
@@ -28,6 +28,7 @@ class BotSettings(BaseSettings):
     jam_session_role_id: int | None = Field(default=None, alias="JAM_SESSION_ROLE_ID")
     web_base_url: str | None = Field(default=None, alias="WEB_BASE_URL")
     opus_api_base_url: str | None = Field(default=None, alias="OPUS_API_BASE_URL")
+    voice_backend: str = Field(default="ffmpeg", alias="VOICE_BACKEND")
 
     # Pydantic v2 configuration
     model_config = SettingsConfigDict(

--- a/apps/bot/jukebotx_bot/voice/backends/__init__.py
+++ b/apps/bot/jukebotx_bot/voice/backends/__init__.py
@@ -1,4 +1,5 @@
 from jukebotx_bot.voice.backends.base import PlaybackBackend
 from jukebotx_bot.voice.backends.discord_ffmpeg import DiscordFFmpegPlaybackBackend
+from jukebotx_bot.voice.backends.lavalink import LavalinkPlaybackBackend
 
-__all__ = ["PlaybackBackend", "DiscordFFmpegPlaybackBackend"]
+__all__ = ["PlaybackBackend", "DiscordFFmpegPlaybackBackend", "LavalinkPlaybackBackend"]

--- a/apps/bot/jukebotx_bot/voice/backends/discord_ffmpeg.py
+++ b/apps/bot/jukebotx_bot/voice/backends/discord_ffmpeg.py
@@ -23,7 +23,7 @@ class DiscordFFmpegPlaybackBackend(PlaybackBackend):
         self._track_end_hooks: list[TrackEndHook] = []
 
     async def connect(self, channel: discord.VocalGuildChannel) -> discord.VoiceClient:
-        return await channel.connect()
+        return await channel.connect(reconnect=False)
 
     async def disconnect(self, voice_client: discord.VoiceClient) -> None:
         await self._cleanup_current_source()

--- a/apps/bot/jukebotx_bot/voice/backends/lavalink.py
+++ b/apps/bot/jukebotx_bot/voice/backends/lavalink.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import logging
+
+import discord
+
+from jukebotx_bot.voice.backends.base import PlaybackBackend, TrackEndHook
+from jukebotx_bot.voice.backends.discord_ffmpeg import DiscordFFmpegPlaybackBackend
+
+
+logger = logging.getLogger(__name__)
+
+
+class LavalinkPlaybackBackend(PlaybackBackend):
+    """
+    Compatibility Lavalink backend.
+
+    This backend allows routing by config during rollout while delegating playback
+    to the existing Discord+FFmpeg implementation until full Lavalink wiring is enabled.
+    """
+
+    def __init__(self, guild_id: int) -> None:
+        self.guild_id = guild_id
+        self._fallback_backend = DiscordFFmpegPlaybackBackend(guild_id)
+        logger.warning(
+            "VOICE_BACKEND=lavalink is enabled for guild=%s; using FFmpeg compatibility backend.",
+            guild_id,
+        )
+
+    async def connect(self, channel: discord.VocalGuildChannel) -> discord.VoiceClient:
+        return await self._fallback_backend.connect(channel)
+
+    async def disconnect(self, voice_client: discord.VoiceClient) -> None:
+        await self._fallback_backend.disconnect(voice_client)
+
+    async def play_track(self, voice_client: discord.VoiceClient, url: str) -> object:
+        return await self._fallback_backend.play_track(voice_client, url)
+
+    async def stop(self, voice_client: discord.VoiceClient) -> None:
+        await self._fallback_backend.stop(voice_client)
+
+    async def skip(self, voice_client: discord.VoiceClient) -> None:
+        await self._fallback_backend.skip(voice_client)
+
+    def is_playing(self, voice_client: discord.VoiceClient) -> bool:
+        return self._fallback_backend.is_playing(voice_client)
+
+    def add_track_end_hook(self, hook: TrackEndHook) -> None:
+        self._fallback_backend.add_track_end_hook(hook)

--- a/apps/bot/jukebotx_bot/voice/service.py
+++ b/apps/bot/jukebotx_bot/voice/service.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import logging
+
+import discord
+
+from jukebotx_bot.discord.audio import AudioControllerManager
+from jukebotx_bot.discord.session import SessionManager, Track
+
+
+logger = logging.getLogger(__name__)
+
+
+class JoinResult(str, Enum):
+    ALREADY_IN_CHANNEL = "already_in_channel"
+    MOVED = "moved"
+    JOINED = "joined"
+
+
+@dataclass(frozen=True)
+class JoinOutcome:
+    result: JoinResult
+    channel_name: str
+
+
+class VoiceOrchestrationService:
+    def __init__(self, *, session_manager: SessionManager, audio_manager: AudioControllerManager) -> None:
+        self._session_manager = session_manager
+        self._audio_manager = audio_manager
+
+    async def join(self, guild: discord.Guild, channel: discord.VocalGuildChannel) -> JoinOutcome:
+        session = self._session_manager.for_guild(guild.id)
+        audio = self._audio_manager.for_guild(guild.id, session)
+        voice_client = guild.voice_client
+
+        if voice_client is not None:
+            if voice_client.channel and voice_client.channel.id == channel.id:
+                return JoinOutcome(JoinResult.ALREADY_IN_CHANNEL, channel.name)
+
+            if voice_client.is_connected():
+                await voice_client.move_to(channel)
+                return JoinOutcome(JoinResult.MOVED, channel.name)
+
+            try:
+                await audio.disconnect(voice_client)
+            except Exception:
+                logger.warning(
+                    "Failed to force-disconnect stale voice client for guild %s",
+                    guild.id,
+                    exc_info=True,
+                )
+
+        await audio.connect(channel)
+        return JoinOutcome(JoinResult.JOINED, channel.name)
+
+    async def leave(self, guild: discord.Guild) -> None:
+        voice_client = guild.voice_client
+        if voice_client is None:
+            return
+
+        session = self._session_manager.for_guild(guild.id)
+        audio = self._audio_manager.for_guild(guild.id, session)
+        await audio.stop(voice_client)
+        await audio.disconnect(voice_client)
+
+    async def play_next(self, guild: discord.Guild) -> Track | None:
+        voice_client = guild.voice_client
+        if voice_client is None:
+            return None
+
+        session = self._session_manager.for_guild(guild.id)
+        audio = self._audio_manager.for_guild(guild.id, session)
+        return await audio.play_next(voice_client)
+
+    async def skip(self, guild: discord.Guild) -> Track | None:
+        voice_client = guild.voice_client
+        if voice_client is None:
+            return None
+
+        session = self._session_manager.for_guild(guild.id)
+        audio = self._audio_manager.for_guild(guild.id, session)
+        return await audio.skip(voice_client)
+
+    async def stop(self, guild: discord.Guild) -> bool:
+        voice_client = guild.voice_client
+        if voice_client is None:
+            return False
+
+        session = self._session_manager.for_guild(guild.id)
+        audio = self._audio_manager.for_guild(guild.id, session)
+        await audio.stop(voice_client)
+        return True


### PR DESCRIPTION
### Motivation
- Decouple high-level voice operations from direct `discord.VoiceClient` manipulation so command handlers can use a single orchestration API.
- Enable gradual rollout of a Lavalink backend by routing playback through a configurable backend layer while preserving current behavior.
- Keep UX unchanged by preserving existing command responses and control flow for join/leave/play/skip/stop.

### Description
- Add `VoiceOrchestrationService` with high-level operations `join`, `leave`, `play_next`, `skip`, and `stop` in `apps/bot/jukebotx_bot/voice/service.py` and model join outcomes with `JoinResult`/`JoinOutcome`.
- Refactor command handlers in `apps/bot/jukebotx_bot/main.py` (`;join`, `;leave`, `;p`, `;n`, `;s`, and autoplay flow) to call the orchestration service instead of manipulating `ctx.guild.voice_client` directly while preserving response strings.
- Add backend selection to `AudioControllerManager` (`backend_name` / `_create_backend`) and expose `connect`/`disconnect` in `GuildAudioController` to enable routing.
- Introduce a `LavalinkPlaybackBackend` compatibility shim at `apps/bot/jukebotx_bot/voice/backends/lavalink.py` that currently delegates to the existing FFmpeg backend to permit gradual rollout, and export it from `voice/backends`.
- Add `VOICE_BACKEND` config (default `ffmpeg`) to `apps/bot/jukebotx_bot/settings.py` and wire `AudioControllerManager`/`VoiceOrchestrationService` construction in `build_bot()` to share `SessionManager` and `AudioControllerManager` instances.
- Minor change: set `reconnect=False` on the FFmpeg `connect` call to match previous explicit behavior.

### Testing
- Ran `python -m compileall apps/bot/jukebotx_bot`, which compiled the package successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abd8ee01d4832f921d70047e5be635)