### PR TITLE
Add Lavalink settings, startup validation, and client wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,17 @@ DISCORD_GUILD_ID=123456789012345678
 WEB_BASE_URL=https://jukebotx.cortocast.com
 PUBLIC_ACTIVITY_CLIENT_ID=123456789012345678
 OPUS_API_BASE_URL=http://api:8000
+VOICE_BACKEND=ffmpeg
+
+# Lavalink (required when VOICE_BACKEND=lavalink)
+LAVALINK_HOST=lavalink
+LAVALINK_PORT=2333
+LAVALINK_PASSWORD=youshallnotpass
+LAVALINK_SECURE=false
+# Optional: stable session id for Lavalink resume support
+LAVALINK_SESSION_ID=
+# Optional: resume timeout (seconds) for Lavalink session recovery
+LAVALINK_RESUME_TIMEOUT_SECONDS=
 
 # Cloudflare Tunnel
 CLOUDFLARED_TOKEN=secret_token

--- a/apps/bot/jukebotx_bot/main.py
+++ b/apps/bot/jukebotx_bot/main.py
@@ -15,6 +15,7 @@ from uuid import UUID
 import discord
 from discord.ext import commands
 import httpx
+import lavalink
 
 from jukebotx_bot.discord.audio import AudioControllerManager
 from jukebotx_bot.discord.now_playing import build_now_playing_embed
@@ -54,6 +55,7 @@ class BotDeps:
     submission_repo: PostgresSubmissionRepository
     queue_repo: PostgresQueueRepository
     voice_service: VoiceOrchestrationService
+    lavalink_client: lavalink.Client | None = None
 
 
 class JukeBot(commands.Bot):
@@ -972,12 +974,29 @@ def build_bot() -> JukeBot:
     Keeps global scope clean and avoids import-time side effects.
     """
     settings = load_bot_settings()
+    settings.validate_startup()
 
     intents = discord.Intents.default()
     intents.message_content = True  # required for prefix commands
 
     session_manager = SessionManager()
     audio_manager = AudioControllerManager(backend_name=settings.voice_backend)
+
+    lavalink_client: lavalink.Client | None = None
+    if settings.is_lavalink_backend:
+        assert settings.lavalink_host is not None
+        assert settings.lavalink_password is not None
+        lavalink_client = lavalink.Client(0)
+        lavalink_client.add_node(
+            host=settings.lavalink_host,
+            port=settings.lavalink_port,
+            password=settings.lavalink_password,
+            region="us",
+            name="jukebotx-main",
+            ssl=settings.lavalink_secure,
+            resume_key=settings.lavalink_session_id,
+            resume_timeout=settings.lavalink_resume_timeout_seconds,
+        )
 
     deps = BotDeps(
         session_manager=session_manager,
@@ -995,6 +1014,7 @@ def build_bot() -> JukeBot:
             session_manager=session_manager,
             audio_manager=audio_manager,
         ),
+        lavalink_client=lavalink_client,
     )
 
     return JukeBot(

--- a/apps/bot/jukebotx_bot/settings.py
+++ b/apps/bot/jukebotx_bot/settings.py
@@ -30,6 +30,16 @@ class BotSettings(BaseSettings):
     opus_api_base_url: str | None = Field(default=None, alias="OPUS_API_BASE_URL")
     voice_backend: str = Field(default="ffmpeg", alias="VOICE_BACKEND")
 
+    lavalink_host: str | None = Field(default=None, alias="LAVALINK_HOST")
+    lavalink_port: int = Field(default=2333, alias="LAVALINK_PORT")
+    lavalink_password: str | None = Field(default=None, alias="LAVALINK_PASSWORD")
+    lavalink_secure: bool = Field(default=False, alias="LAVALINK_SECURE")
+    lavalink_session_id: str | None = Field(default=None, alias="LAVALINK_SESSION_ID")
+    lavalink_resume_timeout_seconds: int | None = Field(
+        default=None,
+        alias="LAVALINK_RESUME_TIMEOUT_SECONDS",
+    )
+
     # Pydantic v2 configuration
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -49,6 +59,32 @@ class BotSettings(BaseSettings):
         if not self.discord_token:
             raise RuntimeError("ENV is not development but DISCORD_TOKEN is not set")
         return self.discord_token
+
+    @property
+    def is_lavalink_backend(self) -> bool:
+        return self.voice_backend.strip().lower() == "lavalink"
+
+    @property
+    def lavalink_uri(self) -> str:
+        scheme = "https" if self.lavalink_secure else "http"
+        return f"{scheme}://{self.lavalink_host}:{self.lavalink_port}"
+
+    def validate_startup(self) -> None:
+        if not self.is_lavalink_backend:
+            return
+
+        missing_vars: list[str] = []
+        if not self.lavalink_host:
+            missing_vars.append("LAVALINK_HOST")
+        if not self.lavalink_password:
+            missing_vars.append("LAVALINK_PASSWORD")
+
+        if missing_vars:
+            joined = ", ".join(missing_vars)
+            raise RuntimeError(
+                "VOICE_BACKEND=lavalink requires the following environment variables: "
+                f"{joined}."
+            )
 
 
 def load_bot_settings() -> BotSettings:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ jinja2 = "^3.1.5"
 uvicorn = {extras = ["standard"], version = "^0.38.0"}
 pynacl = "^1.6.1"
 boto3 = "^1.40.33"
+lavalink = "^5.9.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
### Motivation
- Add configuration and wiring for using a Lavalink voice backend so the bot can optionally route audio through Lavalink. 
- Provide clear startup-time validation so misconfigured Lavalink mode fails fast with an actionable error. 
- Expose optional resume/session settings to support Lavalink resume behavior.

### Description
- Extended `BotSettings` with Lavalink fields: `LAVALINK_HOST`, `LAVALINK_PORT`, `LAVALINK_PASSWORD`, `LAVALINK_SECURE`, `LAVALINK_SESSION_ID`, and `LAVALINK_RESUME_TIMEOUT_SECONDS` and added helper properties `is_lavalink_backend` and `lavalink_uri` in `apps/bot/jukebotx_bot/settings.py`.
- Added `validate_startup()` to `BotSettings` to raise a readable `RuntimeError` if `VOICE_BACKEND=lavalink` but required env vars are missing.
- Wired validation and client initialization into `build_bot()` in `apps/bot/jukebotx_bot/main.py` by calling `settings.validate_startup()`, importing `lavalink`, adding a `lavalink_client` field to `BotDeps`, and creating/configuring a `lavalink.Client` node when Lavalink is selected.
- Added `lavalink = "^5.9.0"` to `pyproject.toml` and updated `.env.example` with `VOICE_BACKEND=...` and documented Lavalink environment variables and defaults.

### Testing
- Ran Python bytecode compilation with `python -m compileall apps/bot/jukebotx_bot`, which completed successfully.
- Attempted to resolve/lock dependencies with `poetry lock`, which failed due to inability to reach `pypi.org` in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abdf4e64dc832fa03f1bc495979e6a)