### PR TITLE
Refactor audio controller tests and split backend adapter coverage

### DIFF
--- a/tests/test_audio_controller.py
+++ b/tests/test_audio_controller.py
@@ -66,10 +66,10 @@ def _build_track(title: str, requester_id: int, requester_name: str) -> Track:
     return Track(
         audio_url=f"https://example.com/{title}.mp3",
         opus_url=None,
-        page_url=None,
+        page_url=f"https://example.com/song/{title}",
         title=title,
-        artist_display=None,
-        media_url=None,
+        artist_display="Test Artist",
+        media_url=f"https://example.com/media/{title}",
         requester_id=requester_id,
         requester_name=requester_name,
     )
@@ -111,9 +111,8 @@ async def test_stop_uses_backend_and_resets_session() -> None:
 
 
 @pytest.mark.asyncio
-async def test_track_end_autoplays_next() -> None:
+async def test_track_end_without_autoplay_stops_playback_and_keeps_queue() -> None:
     session = SessionState()
-    session.autoplay_enabled = True
     session.queue.append(_build_track("track1", 1, "User"))
     session.queue.append(_build_track("track2", 2, "User2"))
     backend = FakePlaybackBackend()
@@ -128,6 +127,46 @@ async def test_track_end_autoplays_next() -> None:
     voice_client.playing = False
     await backend.emit_track_end(voice_client, current_source)
 
+    assert session.now_playing is None
+    assert [track.title for track in session.queue] == ["track2"]
+    assert len(backend.play_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_track_end_autoplay_advances_and_turns_off_when_counter_reaches_zero() -> None:
+    session = SessionState()
+    session.set_autoplay(1)
+    session.queue.append(_build_track("track1", 1, "User"))
+    session.queue.append(_build_track("track2", 2, "User2"))
+    backend = FakePlaybackBackend()
+    controller = GuildAudioController(guild_id=123, session=session, backend=backend)
+    voice_client = FakeVoiceClient()
+
+    first = await controller.play_next(voice_client)
+    assert first is not None
+    assert session.autoplay_enabled
+    current_source = controller._current_source
+    assert current_source is not None
+
+    voice_client.playing = False
+    await backend.emit_track_end(voice_client, current_source)
+
     assert session.now_playing is not None
     assert session.now_playing.title == "track2"
+    assert session.autoplay_enabled is False
+    assert session.autoplay_remaining is None
     assert len(backend.play_calls) == 2
+
+
+def test_session_state_start_next_track_applies_autoplay_transitions_without_backend() -> None:
+    session = SessionState()
+    session.set_autoplay(1)
+    session.queue.append(_build_track("track1", 1, "User"))
+
+    track = session.start_next_track()
+
+    assert track is not None
+    assert track.title == "track1"
+    assert session.now_playing is track
+    assert session.autoplay_enabled is False
+    assert session.autoplay_remaining is None

--- a/tests/test_playback_backends_adapters.py
+++ b/tests/test_playback_backends_adapters.py
@@ -1,0 +1,130 @@
+from pathlib import Path
+import asyncio
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.extend(
+    [
+        str(ROOT / "apps" / "bot"),
+        str(ROOT / "packages" / "core"),
+        str(ROOT / "packages" / "infra"),
+    ]
+)
+
+from jukebotx_bot.voice.backends.discord_ffmpeg import DiscordFFmpegPlaybackBackend
+from jukebotx_bot.voice.backends.lavalink import LavalinkPlaybackBackend
+
+
+class FakeFFmpegPCMAudio:
+    """Distinctive fake source used by adapter tests."""
+
+    def __init__(self, url: str) -> None:
+        self.url = url
+
+
+class FakeVoiceClient:
+    def __init__(self) -> None:
+        self.after = None
+        self.source = None
+        self._is_playing = False
+        self._is_paused = False
+
+    def play(self, source, *, after) -> None:
+        self.source = source
+        self.after = after
+        self._is_playing = True
+
+    def is_playing(self) -> bool:
+        return self._is_playing
+
+    def is_paused(self) -> bool:
+        return self._is_paused
+
+    def stop(self) -> None:
+        self._is_playing = False
+
+
+@pytest.mark.asyncio
+async def test_discord_ffmpeg_backend_registers_and_dispatches_track_end_hook(monkeypatch: pytest.MonkeyPatch) -> None:
+    backend = DiscordFFmpegPlaybackBackend(guild_id=77)
+    fake_source = FakeFFmpegPCMAudio("https://cdn.example.com/track.opus")
+    voice_client = FakeVoiceClient()
+    observed: list[tuple[object, object, Exception | None]] = []
+
+    def fake_build_source(url: str) -> object:
+        assert url == "https://cdn.example.com/track.opus"
+        return fake_source
+
+    async def fake_cleanup_source(source: object) -> None:
+        assert source is fake_source
+
+    backend._loop = asyncio.get_running_loop()
+    monkeypatch.setattr(backend, "_build_source", fake_build_source)
+    monkeypatch.setattr(backend, "_cleanup_source", fake_cleanup_source)
+
+    async def hook(vc, source, error):
+        observed.append((vc, source, error))
+
+    backend.add_track_end_hook(hook)
+
+    source = await backend.play_track(voice_client, "https://cdn.example.com/track.opus")
+    assert source is fake_source
+    assert voice_client.after is not None
+
+    voice_client.after(None)
+    await asyncio.sleep(0)
+
+    assert observed == [(voice_client, fake_source, None)]
+
+
+@pytest.mark.asyncio
+async def test_lavalink_backend_delegates_to_compatibility_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeFallbackBackend:
+        def __init__(self, guild_id: int) -> None:
+            self.guild_id = guild_id
+            self.played: list[str] = []
+            self.hooks = []
+
+        async def connect(self, channel):
+            return "connected"
+
+        async def disconnect(self, voice_client) -> None:
+            return None
+
+        async def play_track(self, voice_client, url: str) -> object:
+            self.played.append(url)
+            return "fallback-source"
+
+        async def stop(self, voice_client) -> None:
+            return None
+
+        async def skip(self, voice_client) -> None:
+            return None
+
+        def is_playing(self, voice_client) -> bool:
+            return False
+
+        def add_track_end_hook(self, hook) -> None:
+            self.hooks.append(hook)
+
+    monkeypatch.setattr("jukebotx_bot.voice.backends.lavalink.DiscordFFmpegPlaybackBackend", FakeFallbackBackend)
+    backend = LavalinkPlaybackBackend(guild_id=88)
+
+    def dummy_hook(*args, **kwargs):
+        return None
+
+    backend.add_track_end_hook(dummy_hook)
+    source = await backend.play_track(FakeVoiceClient(), "https://cdn.example.com/track.mp3")
+
+    assert source == "fallback-source"
+    assert backend._fallback_backend.played == ["https://cdn.example.com/track.mp3"]
+    assert backend._fallback_backend.hooks == [dummy_hook]
+
+
+def test_discord_ffmpeg_backend_rejects_non_audio_page_url() -> None:
+    backend = DiscordFFmpegPlaybackBackend(guild_id=99)
+
+    with pytest.raises(ValueError):
+        backend._assert_audio_url("https://suno.com/song/abc123")


### PR DESCRIPTION
### Motivation
- Tests were out of date with the current `Track` dataclass shape in `apps/bot/jukebotx_bot/discord/session.py` and needed fixtures updated to reflect the new signature. 
- Controller behavior validation should be backend-agnostic, while adapter-specific contracts (FFmpeg vs Lavalink compatibility) deserve separate focused tests. 
- Autoplay/track-end behavior must be validated at the `SessionState` level so transitions are tested independently from transport implementation details. 

### Description
- Updated the `Track` fixture shape in `tests/test_audio_controller.py` to match the current dataclass fields (`audio_url`, `opus_url`, `page_url`, `title`, `artist_display`, `media_url`, `requester_id`, `requester_name`). 
- Kept controller tests backend-agnostic by using `FakePlaybackBackend` and added/renamed tests that assert track-end behavior for no-autoplay and bounded autoplay counter scenarios. 
- Added `tests/test_playback_backends_adapters.py` containing backend-specific adapter tests that cover FFmpeg hook registration/dispatch, Lavalink delegation to the FFmpeg compatibility backend, and FFmpeg URL guard rejection for non-audio page URLs. 
- Introduced distinctive maintenance anchors in tests such as the `Track(...)` fixture and `FakeFFmpegPCMAudio` test-double for fast future search-and-update. 

### Testing
- Attempted to run `pytest -q tests/test_audio_controller.py tests/test_playback_backends_adapters.py`, but the run was blocked by an environment dependency error (`ModuleNotFoundError: No module named 'backports.asyncio'`) from the installed `pytest_asyncio` plugin. 
- Compiled the modified tests successfully with `python3.10 -m compileall tests/test_audio_controller.py tests/test_playback_backends_adapters.py`. 
- Changes were committed; the test files now reflect the current runtime shapes and include adapter coverage for backend implementations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abed70b6c0832faf6686e9ef5dade2)