### PR TITLE
Implement native Lavalink playback backend and track-end hook bridging

### DIFF
--- a/apps/bot/jukebotx_bot/main.py
+++ b/apps/bot/jukebotx_bot/main.py
@@ -22,6 +22,7 @@ from jukebotx_bot.discord.now_playing import build_now_playing_embed
 from jukebotx_bot.discord.session import SessionManager, Track
 from jukebotx_bot.discord.suno import extract_suno_urls
 from jukebotx_bot.settings import load_bot_settings
+from jukebotx_bot.voice.backends.lavalink import LavalinkPlaybackBackend
 from jukebotx_bot.voice.service import JoinResult, VoiceOrchestrationService
 from jukebotx_core.use_cases.ingest_suno_links import IngestSunoLink, IngestSunoLinkInput
 from jukebotx_infra.db import async_session_factory, init_db
@@ -987,6 +988,7 @@ def build_bot() -> JukeBot:
         assert settings.lavalink_host is not None
         assert settings.lavalink_password is not None
         lavalink_client = lavalink.Client(0)
+        LavalinkPlaybackBackend.configure_client(lavalink_client)
         lavalink_client.add_node(
             host=settings.lavalink_host,
             port=settings.lavalink_port,
@@ -997,6 +999,9 @@ def build_bot() -> JukeBot:
             resume_key=settings.lavalink_session_id,
             resume_timeout=settings.lavalink_resume_timeout_seconds,
         )
+
+    else:
+        LavalinkPlaybackBackend.configure_client(None)
 
     deps = BotDeps(
         session_manager=session_manager,

--- a/apps/bot/jukebotx_bot/voice/backends/lavalink.py
+++ b/apps/bot/jukebotx_bot/voice/backends/lavalink.py
@@ -1,49 +1,215 @@
 from __future__ import annotations
 
+import inspect
 import logging
+from typing import TYPE_CHECKING, Any
 
 import discord
 
 from jukebotx_bot.voice.backends.base import PlaybackBackend, TrackEndHook
-from jukebotx_bot.voice.backends.discord_ffmpeg import DiscordFFmpegPlaybackBackend
+
+if TYPE_CHECKING:
+    import lavalink
 
 
 logger = logging.getLogger(__name__)
 
 
 class LavalinkPlaybackBackend(PlaybackBackend):
-    """
-    Compatibility Lavalink backend.
-
-    This backend allows routing by config during rollout while delegating playback
-    to the existing Discord+FFmpeg implementation until full Lavalink wiring is enabled.
-    """
+    _client: "lavalink.Client | None" = None
+    _event_hook_registered = False
+    _backends_by_guild: dict[int, "LavalinkPlaybackBackend"] = {}
 
     def __init__(self, guild_id: int) -> None:
         self.guild_id = guild_id
-        self._fallback_backend = DiscordFFmpegPlaybackBackend(guild_id)
-        logger.warning(
-            "VOICE_BACKEND=lavalink is enabled for guild=%s; using FFmpeg compatibility backend.",
-            guild_id,
-        )
+        self._track_end_hooks: list[TrackEndHook] = []
+        self._voice_client: discord.VoiceClient | None = None
+        type(self)._backends_by_guild[guild_id] = self
+
+    @classmethod
+    def configure_client(cls, client: "lavalink.Client | None") -> None:
+        cls._client = client
+        cls._event_hook_registered = False
+
+    @classmethod
+    async def _dispatch_track_end(cls, event: object) -> None:
+        guild_id = getattr(event, "guild_id", None)
+        if guild_id is None and getattr(event, "player", None) is not None:
+            guild_id = getattr(event.player, "guild_id", None)
+        if guild_id is None:
+            return
+
+        backend = cls._backends_by_guild.get(int(guild_id))
+        if backend is None or backend._voice_client is None:
+            return
+
+        reason = str(getattr(event, "reason", "")).upper()
+        if reason in {"REPLACED", "STOPPED"}:
+            return
+
+        track = getattr(event, "track", None)
+        if track is None and getattr(event, "player", None) is not None:
+            track = getattr(event.player, "current", None)
+
+        exception = getattr(event, "exception", None)
+        if exception is not None and not isinstance(exception, Exception):
+            exception = Exception(str(exception))
+
+        for hook in list(backend._track_end_hooks):
+            result = hook(backend._voice_client, track, exception)
+            if inspect.isawaitable(result):
+                await result
+
+    @classmethod
+    def _register_event_hook_if_needed(cls) -> None:
+        if cls._client is None or cls._event_hook_registered:
+            return
+
+        async def _handler(event: object) -> None:
+            event_name = type(event).__name__.lower()
+            if "trackend" in event_name or "track_end" in event_name:
+                await cls._dispatch_track_end(event)
+
+        client = cls._client
+        assert client is not None
+        if hasattr(client, "add_event_hook"):
+            client.add_event_hook(_handler)
+        elif hasattr(client, "add_event_hooks"):
+            client.add_event_hooks(_handler)
+        else:
+            logger.warning("Lavalink client does not support event hooks; track-end callbacks disabled.")
+            return
+        cls._event_hook_registered = True
+
+    @classmethod
+    def _require_client(cls) -> "lavalink.Client":
+        if cls._client is None:
+            raise RuntimeError("LavalinkPlaybackBackend is not configured with a lavalink client")
+        cls._register_event_hook_if_needed()
+        return cls._client
+
+    @staticmethod
+    async def _maybe_await(value: object) -> object:
+        if inspect.isawaitable(value):
+            return await value
+        return value
+
+    def _get_existing_player(self) -> Any | None:
+        client = self._require_client()
+        player_manager = getattr(client, "player_manager", None)
+        if player_manager is not None and hasattr(player_manager, "get"):
+            return player_manager.get(self.guild_id)
+        if hasattr(client, "get_player"):
+            return client.get_player(self.guild_id)
+        return None
+
+    async def _get_or_create_player(self) -> Any:
+        client = self._require_client()
+        player = self._get_existing_player()
+        if player is not None:
+            return player
+
+        player_manager = getattr(client, "player_manager", None)
+        if player_manager is not None:
+            if hasattr(player_manager, "create"):
+                return await self._maybe_await(player_manager.create(self.guild_id))
+            if hasattr(player_manager, "create_player"):
+                return await self._maybe_await(player_manager.create_player(self.guild_id))
+        if hasattr(client, "create_player"):
+            return await self._maybe_await(client.create_player(self.guild_id))
+
+        raise RuntimeError("Lavalink client does not expose a compatible player creation API")
+
+    async def _resolve_track(self, url: str) -> object:
+        client = self._require_client()
+
+        if hasattr(client, "get_tracks"):
+            result = await self._maybe_await(client.get_tracks(url))
+        elif hasattr(client, "load_tracks"):
+            result = await self._maybe_await(client.load_tracks(url))
+        else:
+            raise RuntimeError("Lavalink client does not expose a track loading API")
+
+        tracks: list[object]
+        if isinstance(result, list):
+            tracks = result
+        elif hasattr(result, "tracks"):
+            tracks = list(result.tracks)
+        elif isinstance(result, dict) and isinstance(result.get("tracks"), list):
+            tracks = result["tracks"]
+        else:
+            tracks = [result]
+
+        if not tracks:
+            raise ValueError(f"No Lavalink tracks resolved for URL: {url}")
+        return tracks[0]
 
     async def connect(self, channel: discord.VocalGuildChannel) -> discord.VoiceClient:
-        return await self._fallback_backend.connect(channel)
+        self._require_client()
+
+        voice_client = channel.guild.voice_client
+        if voice_client is None:
+            voice_client = await channel.connect()
+        elif voice_client.channel != channel:
+            await voice_client.move_to(channel)
+
+        self._voice_client = voice_client
+        await self._get_or_create_player()
+        return voice_client
 
     async def disconnect(self, voice_client: discord.VoiceClient) -> None:
-        await self._fallback_backend.disconnect(voice_client)
+        client = self._require_client()
+
+        player = self._get_existing_player()
+        if player is not None and hasattr(player, "stop"):
+            await self._maybe_await(player.stop())
+
+        if hasattr(client, "player_manager") and hasattr(client.player_manager, "destroy"):
+            await self._maybe_await(client.player_manager.destroy(self.guild_id))
+        elif hasattr(client, "destroy_player"):
+            await self._maybe_await(client.destroy_player(self.guild_id))
+
+        self._voice_client = None
+        await voice_client.disconnect(force=True)
 
     async def play_track(self, voice_client: discord.VoiceClient, url: str) -> object:
-        return await self._fallback_backend.play_track(voice_client, url)
+        self._voice_client = voice_client
+        player = await self._get_or_create_player()
+        track = await self._resolve_track(url)
+
+        if not hasattr(player, "play"):
+            raise RuntimeError("Lavalink player does not support play()")
+
+        await self._maybe_await(player.play(track))
+        return track
 
     async def stop(self, voice_client: discord.VoiceClient) -> None:
-        await self._fallback_backend.stop(voice_client)
+        del voice_client
+        player = self._get_existing_player()
+        if player is not None and hasattr(player, "stop"):
+            await self._maybe_await(player.stop())
 
     async def skip(self, voice_client: discord.VoiceClient) -> None:
-        await self._fallback_backend.skip(voice_client)
+        await self.stop(voice_client)
 
     def is_playing(self, voice_client: discord.VoiceClient) -> bool:
-        return self._fallback_backend.is_playing(voice_client)
+        del voice_client
+
+        try:
+            player = self._get_existing_player()
+        except RuntimeError:
+            return False
+        if player is None:
+            return False
+
+        is_playing = getattr(player, "is_playing", None)
+        if callable(is_playing):
+            return bool(is_playing())
+        if isinstance(is_playing, bool):
+            return is_playing
+        if hasattr(player, "playing"):
+            return bool(player.playing)
+        return getattr(player, "current", None) is not None
 
     def add_track_end_hook(self, hook: TrackEndHook) -> None:
-        self._fallback_backend.add_track_end_hook(hook)
+        self._track_end_hooks.append(hook)

--- a/tests/test_playback_backends_adapters.py
+++ b/tests/test_playback_backends_adapters.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 from pathlib import Path
 import asyncio
 import sys
@@ -79,48 +80,122 @@ async def test_discord_ffmpeg_backend_registers_and_dispatches_track_end_hook(mo
     assert observed == [(voice_client, fake_source, None)]
 
 
+class FakeLavalinkPlayer:
+    def __init__(self, guild_id: int) -> None:
+        self.guild_id = guild_id
+        self.playing = False
+        self.current = None
+
+    async def play(self, track: object) -> None:
+        self.current = track
+        self.playing = True
+
+    async def stop(self) -> None:
+        self.playing = False
+
+
+class FakePlayerManager:
+    def __init__(self) -> None:
+        self.players: dict[int, FakeLavalinkPlayer] = {}
+
+    def get(self, guild_id: int):
+        return self.players.get(guild_id)
+
+    def create(self, guild_id: int):
+        player = FakeLavalinkPlayer(guild_id)
+        self.players[guild_id] = player
+        return player
+
+    async def destroy(self, guild_id: int) -> None:
+        self.players.pop(guild_id, None)
+
+
+class FakeLavalinkClient:
+    def __init__(self) -> None:
+        self.player_manager = FakePlayerManager()
+        self._hooks = []
+
+    def add_event_hook(self, hook):
+        self._hooks.append(hook)
+
+    async def get_tracks(self, url: str):
+        return [{"identifier": url}]
+
+
+class FakeChannel:
+    def __init__(self, guild) -> None:
+        self.guild = guild
+
+
+class FakeGuild:
+    def __init__(self) -> None:
+        self.voice_client = None
+
+
+class FakeDiscordVoiceClient:
+    def __init__(self, guild: FakeGuild, channel: FakeChannel) -> None:
+        self.guild = guild
+        self.channel = channel
+        self.disconnected = False
+
+    async def move_to(self, channel: FakeChannel) -> None:
+        self.channel = channel
+
+    async def disconnect(self, *, force: bool) -> None:
+        assert force is True
+        self.disconnected = True
+        self.guild.voice_client = None
+
+
 @pytest.mark.asyncio
-async def test_lavalink_backend_delegates_to_compatibility_backend(monkeypatch: pytest.MonkeyPatch) -> None:
-    class FakeFallbackBackend:
-        def __init__(self, guild_id: int) -> None:
-            self.guild_id = guild_id
-            self.played: list[str] = []
-            self.hooks = []
+async def test_lavalink_backend_uses_lavalink_player_and_dispatches_end_hooks() -> None:
+    LavalinkPlaybackBackend._backends_by_guild.clear()
+    client = FakeLavalinkClient()
+    LavalinkPlaybackBackend.configure_client(client)
 
-        async def connect(self, channel):
-            return "connected"
-
-        async def disconnect(self, voice_client) -> None:
-            return None
-
-        async def play_track(self, voice_client, url: str) -> object:
-            self.played.append(url)
-            return "fallback-source"
-
-        async def stop(self, voice_client) -> None:
-            return None
-
-        async def skip(self, voice_client) -> None:
-            return None
-
-        def is_playing(self, voice_client) -> bool:
-            return False
-
-        def add_track_end_hook(self, hook) -> None:
-            self.hooks.append(hook)
-
-    monkeypatch.setattr("jukebotx_bot.voice.backends.lavalink.DiscordFFmpegPlaybackBackend", FakeFallbackBackend)
     backend = LavalinkPlaybackBackend(guild_id=88)
+    guild = FakeGuild()
+    channel = FakeChannel(guild)
 
-    def dummy_hook(*args, **kwargs):
-        return None
+    async def connect():
+        vc = FakeDiscordVoiceClient(guild, channel)
+        guild.voice_client = vc
+        return vc
 
-    backend.add_track_end_hook(dummy_hook)
-    source = await backend.play_track(FakeVoiceClient(), "https://cdn.example.com/track.mp3")
+    channel.connect = connect
+    voice_client = await backend.connect(channel)
 
-    assert source == "fallback-source"
-    assert backend._fallback_backend.played == ["https://cdn.example.com/track.mp3"]
-    assert backend._fallback_backend.hooks == [dummy_hook]
+    observed = []
+
+    async def hook(vc, source, error):
+        observed.append((vc, source, error))
+
+    backend.add_track_end_hook(hook)
+
+    source = await backend.play_track(voice_client, "https://cdn.example.com/track.mp3")
+    assert source == {"identifier": "https://cdn.example.com/track.mp3"}
+    assert backend.is_playing(voice_client) is True
+
+    event = type(
+        "TrackEndEvent",
+        (),
+        {
+            "guild_id": 88,
+            "reason": "FINISHED",
+            "track": source,
+            "exception": None,
+        },
+    )()
+    await client._hooks[0](event)
+
+    assert observed == [(voice_client, source, None)]
+
+    await backend.stop(voice_client)
+    assert backend.is_playing(voice_client) is False
+
+    await backend.disconnect(voice_client)
+    assert voice_client.disconnected is True
+    assert client.player_manager.get(88) is None
 
 
 def test_discord_ffmpeg_backend_rejects_non_audio_page_url() -> None:


### PR DESCRIPTION
### Motivation
- Replace the previous FFmpeg compatibility delegation in the Lavalink backend so playback is driven by the Lavalink client/player API rather than an internal `DiscordFFmpegPlaybackBackend` shim. 
- Preserve existing higher-level track-end handling by translating Lavalink track-end events into the backend `TrackEndHook` callbacks so `GuildAudioController._on_track_end` keeps working.

### Description
- Implemented a native `LavalinkPlaybackBackend` that stores a shared client via `LavalinkPlaybackBackend.configure_client(...)` and looks up/creates players using common client/player APIs (`player_manager.get/create`, `create_player`, `get_player`).
- Implemented `connect`, `play_track`, `stop`, `skip`, `is_playing`, and `disconnect` to operate against Lavalink players and to handle a variety of lavalink client method names, with `_maybe_await` helper for sync/async compatibility.
- Added track-end event bridging: `_register_event_hook_if_needed` registers an event hook on the lavalink client and `_dispatch_track_end` translates Lavalink track-end events into registered `TrackEndHook` callbacks (filtering replacement/stopped reasons and converting exceptions as needed).
- Wired startup in `build_bot()` to call `LavalinkPlaybackBackend.configure_client(lavalink_client)` when the lavalink client is created and to call `configure_client(None)` when lavalink is disabled, and updated adapter tests to validate native Lavalink player usage and track-end dispatch.

### Testing
- Ran `ruff check apps/bot/jukebotx_bot/voice/backends/lavalink.py apps/bot/jukebotx_bot/main.py tests/test_playback_backends_adapters.py`, which passed.
- Ran `python -m py_compile apps/bot/jukebotx_bot/voice/backends/lavalink.py apps/bot/jukebotx_bot/main.py tests/test_playback_backends_adapters.py`, which completed successfully.
- Ran `pytest -q tests/test_playback_backends_adapters.py`; the tests are adapted to exercise the new lavalink flow, but `pytest` failed in this environment due to a local test runtime plugin dependency error (`ModuleNotFoundError: No module named 'backports.asyncio'`) rather than code logic failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac0272fd18832fae3d5f0c5ec0b9df)