### PR TITLE
Handle equivalent Lavalink track-end payloads in audio controller

### DIFF
--- a/apps/bot/jukebotx_bot/discord/audio.py
+++ b/apps/bot/jukebotx_bot/discord/audio.py
@@ -88,7 +88,7 @@ class GuildAudioController:
             logger.warning("Playback error in guild %s: %s", self.guild_id, error)
 
         async with self._lock:
-            if self._current_source is not source:
+            if not self._is_current_track_end_event(source, voice_client):
                 return
             self._current_source = None
             self.session.stop_playback()
@@ -110,6 +110,43 @@ class GuildAudioController:
                 return
             if started is not None:
                 await self._announce_now_playing(voice_client, started)
+
+    def _is_current_track_end_event(self, source: object, voice_client: discord.VoiceClient) -> bool:
+        current_source = self._current_source
+        if current_source is None:
+            return False
+
+        if current_source is source:
+            return True
+
+        current_identifier = self._extract_track_match_token(current_source)
+        event_identifier = self._extract_track_match_token(source)
+        if current_identifier and event_identifier and current_identifier == event_identifier:
+            return True
+
+        return (
+            isinstance(self._backend, LavalinkPlaybackBackend)
+            and self.session.now_playing is not None
+            and not self._backend.is_playing(voice_client)
+        )
+
+    @staticmethod
+    def _extract_track_match_token(source: object) -> str | None:
+        if source is None:
+            return None
+
+        if isinstance(source, dict):
+            for key in ("identifier", "track", "uri", "url"):
+                value = source.get(key)
+                if value:
+                    return str(value)
+
+        for key in ("identifier", "track", "uri", "url"):
+            value = getattr(source, key, None)
+            if value:
+                return str(value)
+
+        return None
 
     async def _announce_now_playing(self, voice_client: discord.VoiceClient, track: Track) -> None:
         logger.info(

--- a/tests/test_audio_controller.py
+++ b/tests/test_audio_controller.py
@@ -266,6 +266,30 @@ async def test_play_next_skips_opus_wait_when_backend_prefers_source_audio(monke
 
 
 @pytest.mark.asyncio
+async def test_track_end_autoplay_advances_for_equivalent_lavalink_payload() -> None:
+    session = SessionState()
+    session.set_autoplay(2)
+    session.queue.append(_build_track("track1", 1, "User"))
+    session.queue.append(_build_track("track2", 2, "User2"))
+    backend = FakePreferAudioUrlBackend()
+    controller = GuildAudioController(guild_id=456, session=session, backend=backend)
+    voice_client = FakeVoiceClient()
+
+    first = await controller.play_next(voice_client)
+    assert first is not None
+    current_source = controller._current_source
+    assert isinstance(current_source, str)
+
+    equivalent_source = {"identifier": current_source}
+    voice_client.playing = False
+    await backend.emit_track_end(voice_client, equivalent_source)
+
+    assert session.now_playing is not None
+    assert session.now_playing.title == "track2"
+    assert len(backend.play_calls) == 2
+
+
+@pytest.mark.asyncio
 async def test_play_next_starts_before_duration_probe_finishes(monkeypatch: pytest.MonkeyPatch) -> None:
     session = SessionState()
     track = _build_track("track1", 1, "User")

--- a/tests/test_playback_backends_adapters.py
+++ b/tests/test_playback_backends_adapters.py
@@ -206,13 +206,13 @@ async def test_lavalink_backend_uses_lavalink_player_and_dispatches_end_hooks() 
         {
             "guild_id": 88,
             "reason": "FINISHED",
-            "track": source,
+            "track": {"identifier": source["identifier"]},
             "exception": None,
         },
     )()
     await client._hooks[0](event)
 
-    assert observed == [(voice_client, source, None)]
+    assert observed == [(voice_client, {"identifier": source["identifier"]}, None)]
 
     await backend.stop(voice_client)
     assert backend.is_playing(voice_client) is False


### PR DESCRIPTION
### Motivation
- Lavalink emits track-end events whose payload object identity may differ from the object returned by `play_track`, causing the controller to ignore legitimate end events. 
- The goal is to keep stale-event protection while matching backend-agnostic stable identifiers (or using a Lavalink-specific playback-state fallback) so real track ends always trigger one cleanup and autoplay transitions.

### Description
- Replaced the strict identity check in `GuildAudioController._on_track_end` with a helper `GuildAudioController._is_current_track_end_event` that centralizes matching logic. 
- Added `GuildAudioController._extract_track_match_token` to pull stable identifiers/URLs from payload shapes (checks `identifier`, `track`, `uri`, `url` on dicts and attributes). 
- Implemented a Lavalink fallback in the helper that treats an event as current when `session.now_playing` exists and the Lavalink backend reports no active playback, preserving single-call cleanup semantics (`_current_source = None` and `session.stop_playback()` executed exactly once). 
- Added/updated tests: new controller test `test_track_end_autoplay_advances_for_equivalent_lavalink_payload` in `tests/test_audio_controller.py` and an adapter-level change in `tests/test_playback_backends_adapters.py` to emulate a Lavalink track-end payload whose `track` object shape differs from the original `play_track` return object.

### Testing
- Compiled modified modules with `python -m compileall apps/bot/jukebotx_bot/discord/audio.py tests/test_audio_controller.py tests/test_playback_backends_adapters.py`, which succeeded. 
- Attempted to run `pytest tests/test_audio_controller.py tests/test_playback_backends_adapters.py`, but test execution failed to start due to a missing runtime dependency required by the installed `pytest_asyncio` plugin (`ModuleNotFoundError: No module named 'backports.asyncio'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b063f0efb4832f8c4f56698128f960)