### PR TITLE
Simplify Lavalink-only backend wiring

### DIFF
--- a/apps/bot/jukebotx_bot/discord/audio.py
+++ b/apps/bot/jukebotx_bot/discord/audio.py
@@ -295,13 +295,8 @@ class GuildAudioController:
 
 
 class AudioControllerManager:
-    def __init__(self, *, backend_name: str = "lavalink") -> None:
+    def __init__(self) -> None:
         self._controllers: dict[int, GuildAudioController] = {}
-        self._backend_name = backend_name.strip().lower()
-        if self._backend_name != "lavalink":
-            raise RuntimeError(
-                "Lavalink-only mode is enabled. Set VOICE_BACKEND=lavalink."
-            )
 
     def for_guild(self, guild_id: int, session: SessionState) -> GuildAudioController:
         if guild_id not in self._controllers:

--- a/apps/bot/jukebotx_bot/main.py
+++ b/apps/bot/jukebotx_bot/main.py
@@ -218,10 +218,6 @@ class JukeBot(commands.Bot):
             logging.warning("Failed to prefetch opus status for %s: %s", track_id, exc)
 
     async def _init_lavalink_client(self) -> None:
-        if not self.settings.uses_lavalink:
-            LavalinkPlaybackBackend.configure_client(None)
-            return
-
         assert self.settings.lavalink_host is not None
         assert self.settings.lavalink_password is not None
 
@@ -1636,7 +1632,7 @@ def build_bot() -> JukeBot:
     intents.message_content = True  # required for prefix commands
 
     session_manager = SessionManager()
-    audio_manager = AudioControllerManager(backend_name=settings.voice_backend)
+    audio_manager = AudioControllerManager()
 
     track_repo = PostgresTrackRepository(async_session_factory)
     deps = BotDeps(

--- a/apps/bot/jukebotx_bot/settings.py
+++ b/apps/bot/jukebotx_bot/settings.py
@@ -62,14 +62,6 @@ class BotSettings(BaseSettings):
         return self.discord_token
 
     @property
-    def is_lavalink_backend(self) -> bool:
-        return self.voice_backend.strip().lower() == "lavalink"
-
-    @property
-    def uses_lavalink(self) -> bool:
-        return self.voice_backend.strip().lower() == "lavalink"
-
-    @property
     def lavalink_uri(self) -> str:
         scheme = "https" if self.lavalink_secure else "http"
         return f"{scheme}://{self.lavalink_host}:{self.lavalink_port}"
@@ -80,9 +72,6 @@ class BotSettings(BaseSettings):
             raise RuntimeError(
                 "Lavalink-only mode is enabled. VOICE_BACKEND must be set to 'lavalink'."
             )
-
-        if not self.uses_lavalink:
-            return
 
         missing_vars: list[str] = []
         if not self.lavalink_host:

--- a/tests/test_audio_controller.py
+++ b/tests/test_audio_controller.py
@@ -321,6 +321,6 @@ async def test_play_next_starts_before_duration_probe_finishes(monkeypatch: pyte
 
 
 def test_audio_controller_manager_supports_lavalink_backend_mode() -> None:
-    manager = AudioControllerManager(backend_name="lavalink")
+    manager = AudioControllerManager()
     controller = manager.for_guild(999, SessionState())
     assert isinstance(controller._backend, LavalinkPlaybackBackend)


### PR DESCRIPTION
### Motivation
- Remove duplicated backend flags and tighten startup validation to a single Lavalink-only path to avoid redundant checks and unreachable branches.
- Simplify audio backend wiring so the code always instantiates the Lavalink backend directly, removing guarded constructor logic.
- Update callers and tests to reflect the simplified constructor and assumptions.

### Description
- Removed `is_lavalink_backend` and `uses_lavalink` properties from `BotSettings` and simplified `validate_startup()` to reject non-`lavalink` once then validate required Lavalink env vars (`apps/bot/jukebotx_bot/settings.py`).
- Removed the unreachable non-Lavalink branch from `JukeBot._init_lavalink_client` so initialization now assumes Lavalink-only after validation (`apps/bot/jukebotx_bot/main.py`).
- Simplified `AudioControllerManager` by removing the `backend_name` parameter and guard logic and making it instantiate `LavalinkPlaybackBackend` directly (`apps/bot/jukebotx_bot/discord/audio.py`).
- Updated bot construction to call `AudioControllerManager()` without `backend_name` and adjusted the related unit test to match the new constructor (`apps/bot/jukebotx_bot/main.py`, `tests/test_audio_controller.py`).

### Testing
- Compiled the modified modules with `python -m compileall apps/bot/jukebotx_bot/settings.py apps/bot/jukebotx_bot/main.py apps/bot/jukebotx_bot/discord/audio.py tests/test_audio_controller.py` which succeeded.
- Ran `pytest -q tests/test_audio_controller.py` but the run failed early due to the test environment missing the `backports.asyncio` module required by the installed `pytest_asyncio` plugin, so tests could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b06b3f6bd0832fb34ead05d7643c1b)